### PR TITLE
Refactor illegal sight effects to static helpers

### DIFF
--- a/Systems/ApplyIllegalSightEffects.cs
+++ b/Systems/ApplyIllegalSightEffects.cs
@@ -1,4 +1,4 @@
-﻿// Systems/ApplyIllegalSightEffects.cs
+// Systems/ApplyIllegalSightEffects.cs
 // Invoker system: replaces the legacy StartOfDay/Overnight systems by invoking the new effect-style logic
 // without using GameData or other legacy global lookups. This uses EntityContext (modern) which is used
 // elsewhere in the project (see KillCustomers.cs).
@@ -40,17 +40,18 @@ namespace KitchenMysteryMeat.Systems
                         // Create an EntityContext backed by the project's EntityManager
                         EntityContext ctx = new EntityContext(EntityManager);
 
-                        // For each illegal entity, apply transform or replacement using the Effect classes above
-                        var transformEffect = new Effect_TransformCorpse();
-                        var replaceEffect = new Effect_ReplaceWithAppliance();
-
                         for (int i = illegals.Length - 1; i >= 0; --i)
                         {
                             Entity e = illegals[i];
 
-                            // If the entity is an item or appliance, apply transformEffect which handles both cases.
-                            // transformEffect will internally check for CItem/CAppliance/CPosition and do the right thing.
-                            transformEffect.Apply(ctx, e);
+                            if (ctx.Has<CItem>(e))
+                            {
+                                CorpseEffects.TransformCorpse(ctx, e);
+                            }
+                            else if (ctx.Has<CAppliance>(e))
+                            {
+                                CorpseEffects.ReplaceWithAppliance(ctx, e);
+                            }
                         }
                     }
                 }

--- a/Systems/Effects/Effect_ReplaceWithAppliance.cs
+++ b/Systems/Effects/Effect_ReplaceWithAppliance.cs
@@ -1,28 +1,24 @@
-﻿// Systems/Effects/Effect_ReplaceWithAppliance.cs
-// Effect that replaces the current entity with the appliance ID stored in the entity's CIllegalSight.
+// Systems/Effects/Effect_ReplaceWithAppliance.cs
+// Static helper that replaces the current entity with the appliance ID stored in the entity's CIllegalSight.
 // Useful for overnight replacements.
 
 using Kitchen;
-using KitchenMods;
-using KitchenLib.Customs;
 using KitchenMysteryMeat.Components;
-using System.Reflection;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems.Effects
 {
-    public class Effect_ReplaceWithAppliance : Effect, IEffect
+    public static partial class CorpseEffects
     {
-        public override void Apply(EntityContext ctx, Entity entity)
+        public static void ReplaceWithAppliance(EntityContext ctx, Entity entity)
         {
             if (!ctx.Has<CIllegalSight>(entity))
                 return;
 
-            var illegal = ctx.Get<CIllegalSight>(entity);
-
-            if (!ctx.Has<CPosition>(entity))
+            if (!ctx.Has<CAppliance>(entity) || !ctx.Has<CPosition>(entity))
                 return;
 
+            var illegal = ctx.Get<CIllegalSight>(entity);
             var pos = ctx.Get<CPosition>(entity);
 
             // Create new appliance entity

--- a/Systems/Effects/Effect_TransformCorpse.cs
+++ b/Systems/Effects/Effect_TransformCorpse.cs
@@ -1,73 +1,48 @@
-﻿// Systems/Effects/Effect_TransformCorpse.cs
-// Effect-style transform: turns an entity that carries CIllegalSight into its configured TurnIntoOnDayStart item.
+// Systems/Effects/Effect_TransformCorpse.cs
+// Static helper: turns an entity that carries CIllegalSight into its configured TurnIntoOnDayStart item.
 // Uses EntityContext (modern API already used in this project) and does not use KitchenData lookups.
 
 using Kitchen;
-using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System.Reflection;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems.Effects
 {
-    public class Effect_TransformCorpse : Effect, IEffect
+    public static partial class CorpseEffects
     {
-        // Apply is called with an EntityContext by the invoker system (below).
-        public override void Apply(EntityContext ctx, Entity entity)
+        public static void TransformCorpse(EntityContext ctx, Entity entity)
         {
-            // Only act if the entity actually has CIllegalSight (the data-driven TurnIntoOnDayStart)
             if (!ctx.Has<CIllegalSight>(entity))
+                return;
+
+            if (!ctx.Has<CItem>(entity))
                 return;
 
             CIllegalSight illegal = ctx.Get<CIllegalSight>(entity);
 
-            // ITEM CASE: if entity is an item, attempt to queue a change
-            if (ctx.Has<CItem>(entity))
+            // If item is held, ensure the holder does not preserve contents overnight.
+            if (ctx.Has<CHeldBy>(entity))
             {
-                // If item is held, ensure the holder does not preserve contents overnight.
-                if (ctx.Has<CHeldBy>(entity))
+                CHeldBy holder = ctx.Get<CHeldBy>(entity);
+                if (holder.Holder != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holder.Holder))
                 {
-                    CHeldBy holder = ctx.Get<CHeldBy>(entity);
-                    if (holder.Holder != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holder.Holder))
-                    {
-                        // Holder preserves contents — do nothing.
-                        return;
-                    }
+                    // Holder preserves contents — do nothing.
+                    return;
                 }
-
-                // Add the change marker (CChangeItemType) using the modern context API.
-                ctx.Set(entity, new CChangeItemType { NewID = illegal.TurnIntoOnDayStart });
-
-                // Preserve portions if splittable
-                if (ctx.Has<CSplittableItem>(entity))
-                {
-                    var split = ctx.Get<CSplittableItem>(entity);
-                    ctx.Set(entity, new CPersistPortions
-                    {
-                        RemainingCount = split.RemainingCount,
-                        TotalCount = split.TotalCount
-                    });
-                }
-
-                return;
             }
 
-            // APPLIANCE CASE: spawn a new appliance and remove the old one
-            if (ctx.Has<CAppliance>(entity) && ctx.Has<CPosition>(entity))
+            // Add the change marker (CChangeItemType) using the modern context API.
+            ctx.Set(entity, new CChangeItemType { NewID = illegal.TurnIntoOnDayStart });
+
+            // Preserve portions if splittable
+            if (ctx.Has<CSplittableItem>(entity))
             {
-                var pos = ctx.Get<CPosition>(entity);
-
-                // Create a new appliance entity and mark it for creation by using CCreateAppliance + position
-                Entity newAppliance = ctx.CreateEntity();
-                ctx.Set(newAppliance, new CCreateAppliance
+                var split = ctx.Get<CSplittableItem>(entity);
+                ctx.Set(entity, new CPersistPortions
                 {
-                    ID = illegal.TurnIntoOnDayStart,
-                    ForceLayer = OccupancyLayer.Ceiling
+                    RemainingCount = split.RemainingCount,
+                    TotalCount = split.TotalCount
                 });
-                ctx.Set(newAppliance, pos);
-
-                // Destroy the original entity
-                ctx.Destroy(entity);
             }
         }
     }


### PR DESCRIPTION
## Summary
- replace the legacy Effect-derived classes with a static CorpseEffects helper
- update ApplyIllegalSightEffects to call the helper methods for items and appliances

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cde4916fe8832ebd4484f255703a4e