### PR TITLE
Add missing PlateUp references

### DIFF
--- a/MysteryMeat.csproj
+++ b/MysteryMeat.csproj
@@ -22,11 +22,32 @@
 		<Reference Include="KitchenMods">
 		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\KitchenMods.dll</HintPath>
 		</Reference>
+		<Reference Include="Kitchen">
+		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\Kitchen.dll</HintPath>
+		</Reference>
+		<Reference Include="Kitchen.GameData">
+		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\Kitchen.GameData.dll</HintPath>
+		</Reference>
 		<Reference Include="Unity.Entities">
 		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\Unity.Entities.dll</HintPath>
 		</Reference>
+		<Reference Include="MessagePack">
+		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\MessagePack.dll</HintPath>
+		</Reference>
+		<Reference Include="Unity.TextMeshPro">
+		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+		</Reference>
 		<Reference Include="UnityEngine.CoreModule">
 		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+		</Reference>
+		<Reference Include="UnityEngine.UI">
+		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\UnityEngine.UI.dll</HintPath>
+		</Reference>
+		<Reference Include="HarmonyLib">
+		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\HarmonyLib.dll</HintPath>
+		</Reference>
+		<Reference Include="PreferenceSystem">
+		  <HintPath>X:\SteamLibrary\steamapps\workshop\content\1599600\2847087562\PreferenceSystem-Workshop.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 


### PR DESCRIPTION
## Summary
- add missing base game and dependency assemblies to MysteryMeat.csproj so the mod can resolve Kitchen, MessagePack, TMPro, Harmony, and PreferenceSystem types

## Testing
- not run (dotnet CLI is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cde8c6f734832e90274f757ce398d6