### PR TITLE
Guard corpse and appliance replacements without targets

### DIFF
--- a/Systems/Effects/Effect_ReplaceWithAppliance.cs
+++ b/Systems/Effects/Effect_ReplaceWithAppliance.cs
@@ -22,6 +22,9 @@ namespace KitchenMysteryMeat.Systems.Effects
             var illegal = ctx.Get<CIllegalSight>(entity);
             var pos = ctx.Get<CPosition>(entity);
 
+            if (illegal.TurnIntoOnDayStart <= 0)
+                return;
+
             // Create new appliance entity
             Entity newEntity = ctx.CreateEntity();
             ctx.Set(newEntity, new CCreateAppliance

--- a/Systems/Effects/Effect_TransformCorpse.cs
+++ b/Systems/Effects/Effect_TransformCorpse.cs
@@ -20,6 +20,9 @@ namespace KitchenMysteryMeat.Systems.Effects
 
             CIllegalSight illegal = ctx.Get<CIllegalSight>(entity);
 
+            if (illegal.TurnIntoOnDayStart <= 0)
+                return;
+
             // If item is held, ensure the holder does not preserve contents overnight.
             if (ctx.Has<CHeldBy>(entity))
             {


### PR DESCRIPTION
## Summary
- avoid transforming corpses when their replacement ID is invalid
- skip appliance replacement when no valid appliance is configured

## Testing
- dotnet test *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1503ad90832ea112bac97c4c61ec