### PR TITLE
Guard illegal sight overnight flags

### DIFF
--- a/Systems/ApplyIllegalSightOvernightFlags.cs
+++ b/Systems/ApplyIllegalSightOvernightFlags.cs
@@ -33,6 +33,10 @@ namespace KitchenMysteryMeat.Systems
             for (int i = 0; i < illegals.Length; ++i)
             {
                 Entity entity = illegals[i];
+                CIllegalSight illegal = EntityManager.GetComponentData<CIllegalSight>(entity);
+
+                if (illegal.TurnIntoOnDayStart <= 0)
+                    continue;
 
                 if (EntityManager.HasComponent<CItem>(entity))
                 {


### PR DESCRIPTION
## Summary
- read each illegal sight's data before toggling overnight components
- skip preservation/destruction overrides when the illegal sight has no overnight replacement target

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1626a75c832e80eac05d19236e19