### PR TITLE
Migrate GrindMeat localisation to InfoList

### DIFF
--- a/Customs/Processes/GrindMeat.cs
+++ b/Customs/Processes/GrindMeat.cs
@@ -2,11 +2,7 @@
 using KitchenLib.Customs;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Customs.Appliances;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Customs.Processes
 {
@@ -22,17 +18,10 @@ namespace KitchenMysteryMeat.Customs.Processes
         // Whether or not the process can be obfuscated, such as through the "Blindfolded Chefs" card. This is normally set to `true`
         public override bool CanObfuscateProgress => true;
 
-        // The localization information for this process. This must be set for at least one language. 
-        public override LocalisationObject<ProcessInfo> Info
+        // The localization information for this process. This must be set for at least one language.
+        public override List<(Locale, ProcessInfo)> InfoList => new()
         {
-            get
-            {
-                var info = new LocalisationObject<ProcessInfo>();
-
-                info.Add(Locale.English, LocalisationUtils.CreateProcessInfo("Grind", "<sprite name=\"grindmeat\">"));
-
-                return info;
-            }
-        }
+            (Locale.English, LocalisationUtils.CreateProcessInfo("Grind", "<sprite name=\"grindmeat\">"))
+        };
     }
 }


### PR DESCRIPTION
## Summary
- replace the GrindMeat localisation override with the new InfoList implementation
- tidy unused usings removed during the migration

## Testing
- dotnet build *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce177fb8e8832eb065a9abb3546b91