### PR TITLE
Bump release to 0.3.0

### DIFF
--- a/Changelogs/GitHub/v0.3.0.md
+++ b/Changelogs/GitHub/v0.3.0.md
@@ -1,0 +1,6 @@
+# Release Notes v0.3.0
+
+## Highlights
+- Migrated the legacy corpse cleanup logic to the Fully Loaded effect pipeline so illegal sights convert or persist using the new systems without relying on GameData hacks.
+- Added a dedicated overnight flag system that respects the Persistent Corpses setting while letting blood splatters and other authored messes clean up between days.
+- Centralised the mod version in code for easier future bumps and updated the release to v0.3.0.

--- a/Changelogs/Workshop/v0.3.0.bbcode
+++ b/Changelogs/Workshop/v0.3.0.bbcode
@@ -1,0 +1,7 @@
+[h1]Release Notes v0.3.0[/h1]
+[h2]Highlights[/h2]
+[list]
+[*]Migrated the corpse cleanup workflow to the Fully Loaded effect pipeline so illegal sights upgrade or persist without legacy GameData patches.
+[*]Added a runtime overnight flag system that honours the Persistent Corpses preference while still clearing authored messes like blood between days.
+[*]Centralised the mod version metadata and bumped the release to v0.3.0 for simpler future maintenance.
+[/list]

--- a/Mod.cs
+++ b/Mod.cs
@@ -1,3 +1,4 @@
+using System;
 using KitchenLib;
 using KitchenLib.Logging.Exceptions;
 using KitchenMods;
@@ -23,14 +24,15 @@ namespace KitchenMysteryMeat
     {
         public const string MOD_GUID = "com.quackandcheese.mysterymeat";
         public const string MOD_NAME = "Mystery Meat";
-        public const string MOD_VERSION = "0.2.1";
+        public static readonly Version ModVersion = new Version(0, 3, 0);
+        public static string ModVersionString => ModVersion.ToString();
         public const string MOD_AUTHOR = "QuackAndCheese";
         public const string MOD_GAMEVERSION = ">=1.1.9";
 
         internal static AssetBundle Bundle;
         internal static KitchenLogger Logger;
 
-        public Mod() : base(MOD_GUID, MOD_NAME, MOD_AUTHOR, MOD_VERSION, MOD_GAMEVERSION, Assembly.GetExecutingAssembly()) { }
+        public Mod() : base(MOD_GUID, MOD_NAME, MOD_AUTHOR, ModVersionString, MOD_GAMEVERSION, Assembly.GetExecutingAssembly()) { }
 
         public static SoundEvent StabSoundEvent;
         public static SoundEvent PoisonSoundEvent;
@@ -48,7 +50,7 @@ namespace KitchenMysteryMeat
 
         protected override void OnInitialise()
         {
-            Logger.LogWarning($"{MOD_GUID} v{MOD_VERSION} in use!");
+            Logger.LogWarning($"{MOD_GUID} v{ModVersion} in use!");
         }
 
         protected override void OnUpdate()


### PR DESCRIPTION
## Summary
- centralise the mod version metadata in a single `System.Version` value and bump it to 0.3.0
- add matching 0.3.0 release notes for GitHub and Workshop packaging

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ce0e120874832ebe9b2043277bc179