### PR TITLE
Use vanilla leave flow for alerted customers

### DIFF
--- a/Components/CAlertedCustomer.cs
+++ b/Components/CAlertedCustomer.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Components
 {
-    public struct CRunningAway : IModComponent
+    public struct CAlertedCustomer : IModComponent
     {
     }
 }

--- a/Systems/EscapedGameOver.cs
+++ b/Systems/EscapedGameOver.cs
@@ -23,7 +23,7 @@ namespace KitchenMysteryMeat.Systems
             base.Initialise();
 
             Customers = GetEntityQuery(new QueryHelper()
-                            .All(typeof(CPosition), typeof(CRunningAway), typeof(CCustomer)));
+                            .All(typeof(CPosition), typeof(CCustomer), typeof(CCustomerLeaving), typeof(CAlertedCustomer)));
         }
 
         protected override void OnUpdate()

--- a/Systems/ISeeDeadPeople.cs
+++ b/Systems/ISeeDeadPeople.cs
@@ -25,7 +25,7 @@ namespace KitchenMysteryMeat.Systems
             Customers = GetEntityQuery(new QueryHelper()
                             .All(typeof(CCustomer), typeof(CPosition), typeof(CSuspicionIndicator), typeof(CBelongsToGroup))
                             .None(
-                                typeof(CRunningAway)
+                                typeof(CAlertedCustomer)
                             ));
             IllegalEntities = GetEntityQuery(new QueryHelper()
                             .All(typeof(CIllegalSight)));

--- a/Systems/UpdateCustomerSuspicion.cs
+++ b/Systems/UpdateCustomerSuspicion.cs
@@ -79,9 +79,22 @@ namespace KitchenMysteryMeat.Systems
 
                     // Make leave
                     susIndicator.IndicatorType = SuspicionIndicatorType.Alert;
-                    EntityManager.AddComponent<CCustomerLeaving>(customer);
-                    EntityManager.AddComponent<CRunningAway>(customer);
                     EntityManager.SetComponentData(customer, susIndicator);
+
+                    if (!Has<CCustomerLeaving>(customer))
+                    {
+                        EntityManager.AddComponent<CCustomerLeaving>(customer);
+                    }
+
+                    if (!Has<CAlertedCustomer>(customer))
+                    {
+                        EntityManager.AddComponent<CAlertedCustomer>(customer);
+                    }
+
+                    if (Require<CBelongsToGroup>(customer, out CBelongsToGroup alertGroup) && !Has<CGroupStartLeaving>(alertGroup.Group))
+                    {
+                        EntityManager.AddComponent<CGroupStartLeaving>(alertGroup.Group);
+                    }
 
                     CSoundEvent.Create(EntityManager, Mod.AlertSoundEvent);
                 }


### PR DESCRIPTION
## Summary
- replace the custom running away tag with a new `CAlertedCustomer` marker and trigger the vanilla group leave flow so customers use navmesh exits
- update detection and escape systems to look for the new marker alongside `CCustomerLeaving`
- add the new marker component definition in place of the removed `CRunningAway`

## Testing
- not run (in-game testing required)


------
https://chatgpt.com/codex/tasks/task_e_68ce263c47d8832e9c86cbcf8e0aba08