### PR TITLE
Ensure alerted customers request nav exit

### DIFF
--- a/Systems/UpdateCustomerSuspicion.cs
+++ b/Systems/UpdateCustomerSuspicion.cs
@@ -86,6 +86,11 @@ namespace KitchenMysteryMeat.Systems
                         EntityManager.AddComponent<CCustomerLeaving>(customer);
                     }
 
+                    if (Has<CMoveToLocation>(customer))
+                    {
+                        EntityManager.RemoveComponent<CMoveToLocation>(customer);
+                    }
+
                     if (!Has<CAlertedCustomer>(customer))
                     {
                         EntityManager.AddComponent<CAlertedCustomer>(customer);


### PR DESCRIPTION
## Summary
- mirror vanilla leave handling by removing `CMoveToLocation` from alerted customers so they can request a navmesh exit path when suspicion trips

## Testing
- dotnet build *(fails: missing KitchenLib and related dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce36fadb6c832ea6490071dc578c81