### PR TITLE
Ensure alerted customers trigger full group exit flow

### DIFF
--- a/Systems/UpdateCustomerSuspicion.cs
+++ b/Systems/UpdateCustomerSuspicion.cs
@@ -96,12 +96,80 @@ namespace KitchenMysteryMeat.Systems
                         EntityManager.AddComponent<CAlertedCustomer>(customer);
                     }
 
-                    if (Require<CBelongsToGroup>(customer, out CBelongsToGroup alertGroup) && !Has<CGroupStartLeaving>(alertGroup.Group))
+                    if (Require<CBelongsToGroup>(customer, out CBelongsToGroup alertGroup))
                     {
-                        EntityManager.AddComponent<CGroupStartLeaving>(alertGroup.Group);
+                        EnsureGroupLeaves(alertGroup.Group);
                     }
 
                     CSoundEvent.Create(EntityManager, Mod.AlertSoundEvent);
+                }
+            }
+        }
+
+        private void EnsureGroupLeaves(Entity group)
+        {
+            if (group == default)
+            {
+                return;
+            }
+
+            if (!Has<CGroupStartLeaving>(group))
+            {
+                EntityManager.AddComponent<CGroupStartLeaving>(group);
+            }
+
+            if (!Has<CGroupLeaving>(group))
+            {
+                EntityManager.AddComponent<CGroupLeaving>(group);
+            }
+
+            if (!Has<CGroupStateChanged>(group))
+            {
+                EntityManager.AddComponent<CGroupStateChanged>(group);
+            }
+
+            if (Has<CGroupAwaitingOrder>(group))
+            {
+                EntityManager.RemoveComponent<CGroupAwaitingOrder>(group);
+            }
+
+            if (Has<CGroupReadyToOrder>(group))
+            {
+                EntityManager.RemoveComponent<CGroupReadyToOrder>(group);
+            }
+
+            if (Has<CQueuePosition>(group))
+            {
+                EntityManager.RemoveComponent<CQueuePosition>(group);
+            }
+
+            if (Require<CAssignedTable>(group, out CAssignedTable assignedTable) && assignedTable.Table != default)
+            {
+                EntityManager.RemoveComponent<CAssignedTable>(group);
+
+                if (Has<COccupiedByGroup>(assignedTable.Table))
+                {
+                    EntityManager.RemoveComponent<COccupiedByGroup>(assignedTable.Table);
+                }
+            }
+
+            if (Require<CAssignedMenu>(group, out CAssignedMenu assignedMenu) && assignedMenu.Menu != default)
+            {
+                EntityManager.RemoveComponent<CAssignedMenu>(group);
+
+                if (Has<COccupiedByGroup>(assignedMenu.Menu))
+                {
+                    EntityManager.RemoveComponent<COccupiedByGroup>(assignedMenu.Menu);
+                }
+            }
+
+            if (Require<CAssignedStand>(group, out CAssignedStand assignedStand) && assignedStand.Stand != default)
+            {
+                EntityManager.RemoveComponent<CAssignedStand>(group);
+
+                if (Has<COccupiedByGroup>(assignedStand.Stand))
+                {
+                    EntityManager.RemoveComponent<COccupiedByGroup>(assignedStand.Stand);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- ensure UpdateCustomerSuspicion applies the same group-leaving tags and clean-up that vanilla systems do when forcing departures
- refactor leaving logic into a helper that de-duplicates component additions and removes lingering assignments from the group

## Testing
- dotnet build *(fails: missing KitchenLib dependencies in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68ce41380584832ebbe262ae27f73043