### PR TITLE
Document alerted customer marker usage

### DIFF
--- a/Components/CAlertedCustomer.cs
+++ b/Components/CAlertedCustomer.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Flags a diner who has been alerted and has transitioned into the forced-leave flow.
+    /// </summary>
     public struct CAlertedCustomer : IModComponent
     {
     }

--- a/Systems/EscapedGameOver.cs
+++ b/Systems/EscapedGameOver.cs
@@ -24,6 +24,7 @@ namespace KitchenMysteryMeat.Systems
             base.Initialise();
 
             Customers = GetEntityQuery(new QueryHelper()
+                            // Watch only the alerted leavers so exiting them triggers the lose condition.
                             .All(typeof(CPosition), typeof(CCustomer), typeof(CCustomerLeaving), typeof(CAlertedCustomer)));
 
             ReachedDestinationComponentType = TryGetReachedDestinationComponentType();

--- a/Systems/ISeeDeadPeople.cs
+++ b/Systems/ISeeDeadPeople.cs
@@ -24,6 +24,7 @@ namespace KitchenMysteryMeat.Systems
 
             Customers = GetEntityQuery(new QueryHelper()
                             .All(typeof(CCustomer), typeof(CPosition), typeof(CSuspicionIndicator), typeof(CBelongsToGroup))
+                            // Skip customers already marked as alerted so we do not re-trigger their panic logic.
                             .None(
                                 typeof(CAlertedCustomer)
                             ));

--- a/Systems/UpdateCustomerSuspicion.cs
+++ b/Systems/UpdateCustomerSuspicion.cs
@@ -93,6 +93,7 @@ namespace KitchenMysteryMeat.Systems
 
                     if (!Has<CAlertedCustomer>(customer))
                     {
+                        // Tag the diner so other systems treat them as part of the forced-leave sequence.
                         EntityManager.AddComponent<CAlertedCustomer>(customer);
                     }
 


### PR DESCRIPTION
## Summary
- document the alerted customer marker struct to explain the forced-leave flow
- add inline comments where the alert flag is used to clarify the forced-leave handling

## Testing
- dotnet format MysteryMeat.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4999b898832e97b9302e3f214e0c