### PR TITLE
Extend v0.3.0 changelogs with prior release notes

### DIFF
--- a/Changelogs/GitHub/v0.3.0.md
+++ b/Changelogs/GitHub/v0.3.0.md
@@ -1,6 +1,29 @@
 # Release Notes v0.3.0
-
 ## Highlights
 - Migrated the legacy corpse cleanup logic to the Fully Loaded effect pipeline so illegal sights convert or persist using the new systems without relying on GameData hacks.
 - Added a dedicated overnight flag system that respects the Persistent Corpses setting while letting blood splatters and other authored messes clean up between days.
 - Centralised the mod version in code for easier future bumps and updated the release to v0.3.0.
+
+## v0.2.0 – Persistent Corpses update
+- Added a Persistent Corpses unlock card that requires the burger dish and keeps bodies around between days.
+- Introduced in-game preferences for individual audio volumes and toggles to enable or disable specific cards, including Persistent Corpses.
+- Reduced the Special Sauce provider’s shop price in line with the Steam notes.
+
+## v0.1.4 – Manual Meat Grinder
+- Added a purchasable Manual Meat Grinder appliance that upgrades into the Automatic model.
+- Reworked the Automatic Meat Grinder as the upgraded form with automated conveyance handling.
+
+## v0.1.3 – Alerted customer bugfix
+- Ensured alerted customers still trigger a life loss when they make it outside, matching the Steam hotfix.
+
+## v0.1.2 – Colorblind+ compatibility
+- Removed problematic Colorblind+ assets from sauce bottles to prevent loading crashes.
+
+## v0.1.1 – Balance & polish
+- Set the Mystery Meat Burger to use the small customer decrease (-15%) multiplier for a lighter penalty.
+- Locked corpses to outside rubbish and made them indisposable indoors.
+- Added suspicion indicators to practice cats through the LocalViewRouter postfix patch.
+
+## v0.1.0 – Initial release
+- Debuted the suspicion indicator system with dynamic visuals and audio feedback.
+- Shipped the core Mystery Meat menu and themed unlock cards like Cautious Crowd and Messy Murder.

--- a/Changelogs/Workshop/v0.3.0.bbcode
+++ b/Changelogs/Workshop/v0.3.0.bbcode
@@ -5,3 +5,39 @@
 [*]Added a runtime overnight flag system that honours the Persistent Corpses preference while still clearing authored messes like blood between days.
 [*]Centralised the mod version metadata and bumped the release to v0.3.0 for simpler future maintenance.
 [/list]
+
+[h2]v0.2.0 – Persistent Corpses update[/h2]
+[list]
+[*]Added a Persistent Corpses unlock card that requires the burger dish and keeps bodies around between days.
+[*]Introduced in-game preferences for individual audio volumes and toggles to enable or disable specific cards, including Persistent Corpses.
+[*]Reduced the Special Sauce provider’s shop price in line with the Steam notes.
+[/list]
+
+[h2]v0.1.4 – Manual Meat Grinder[/h2]
+[list]
+[*]Added a purchasable Manual Meat Grinder appliance that upgrades into the Automatic model.
+[*]Reworked the Automatic Meat Grinder as the upgraded form with automated conveyance handling.
+[/list]
+
+[h2]v0.1.3 – Alerted customer bugfix[/h2]
+[list]
+[*]Ensured alerted customers still trigger a life loss when they make it outside, matching the Steam hotfix.
+[/list]
+
+[h2]v0.1.2 – Colorblind+ compatibility[/h2]
+[list]
+[*]Removed problematic Colorblind+ assets from sauce bottles to prevent loading crashes.
+[/list]
+
+[h2]v0.1.1 – Balance & polish[/h2]
+[list]
+[*]Set the Mystery Meat Burger to use the small customer decrease (-15%) multiplier for a lighter penalty.
+[*]Locked corpses to outside rubbish and made them indisposable indoors.
+[*]Added suspicion indicators to practice cats through the LocalViewRouter postfix patch.
+[/list]
+
+[h2]v0.1.0 – Initial release[/h2]
+[list]
+[*]Debuted the suspicion indicator system with dynamic visuals and audio feedback.
+[*]Shipped the core Mystery Meat menu and themed unlock cards like Cautious Crowd and Messy Murder.
+[/list]


### PR DESCRIPTION
## Summary
- append the v0.2.0 through v0.1.0 release notes to the GitHub changelog so v0.3.0 references the full history
- mirror the same release history additions in the Workshop bbcode changelog

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68ce4f075094832e8d208bf8c2c88e6f