### PR TITLE
Add local path configuration template and update references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 ## Get latest from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
 
 # User-specific files
+Directory.Build.props
 *.rsuser
 *.suo
 *.user

--- a/Directory.Build.props.sample
+++ b/Directory.Build.props.sample
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <!-- Update these paths to match your local PlateUp installation -->
+    <PlateUpManagedDir>C:\Program Files (x86)\Steam\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed</PlateUpManagedDir>
+    <PlateUpWorkshopDir>C:\Program Files (x86)\Steam\steamapps\workshop\content\1599600</PlateUpWorkshopDir>
+  </PropertyGroup>
+</Project>

--- a/MysteryMeat.csproj
+++ b/MysteryMeat.csproj
@@ -8,72 +8,80 @@
 		<Platforms>AnyCPU;x64</Platforms>
 	</PropertyGroup>
 
-	<!-- This is the section you need to add for external file references -->
+	<!-- External references resolved via local PlateUp installation -->
 	<ItemGroup>
 		<!-- PlateUp! Core DLLs for v1.2.1+ -->
-		<Reference Include="Kitchen.Common">
-		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\Kitchen.Common.dll</HintPath>
+		<Reference Include="Kitchen.Common" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\Kitchen.Common.dll</HintPath>
 		</Reference>
-		<Reference Include="Kitchen.GameData">
-		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\Kitchen.GameData.dll</HintPath>
+		<Reference Include="Kitchen.GameData" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\Kitchen.GameData.dll</HintPath>
 		</Reference>
-		<Reference Include="Kitchen.RestaurantMode">
-			<HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\Kitchen.RestaurantMode.dll</HintPath>
+		<Reference Include="Kitchen.RestaurantMode" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\Kitchen.RestaurantMode.dll</HintPath>
 		</Reference>
-		<Reference Include="KitchenMode">
-			<HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\KitchenMode.dll</HintPath>
+		<Reference Include="KitchenMode" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\KitchenMode.dll</HintPath>
 		</Reference>
-		<Reference Include="KitchenMods">
-			<HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\KitchenMods.dll</HintPath>
+		<Reference Include="KitchenMods" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\KitchenMods.dll</HintPath>
 		</Reference>
-		<Reference Include="MessagePack">
-			<HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\MessagePack.dll</HintPath>
+		<Reference Include="MessagePack" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\MessagePack.dll</HintPath>
 		</Reference>
-		<Reference Include="MessagePack.Annotations">
-		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\MessagePack.Annotations.dll</HintPath>
+		<Reference Include="MessagePack.Annotations" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\MessagePack.Annotations.dll</HintPath>
 		</Reference>
-		<Reference Include="Sirenix.Serialization">
-		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\Sirenix.Serialization.dll</HintPath>
+		<Reference Include="Sirenix.Serialization" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\Sirenix.Serialization.dll</HintPath>
 		</Reference>
-		<Reference Include="Unity.Entities">
-		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\Unity.Entities.dll</HintPath>
+		<Reference Include="Unity.Entities" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\Unity.Entities.dll</HintPath>
 		</Reference>
-		<Reference Include="Unity.Mathematics">
-		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\Unity.Mathematics.dll</HintPath>
+		<Reference Include="Unity.Mathematics" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\Unity.Mathematics.dll</HintPath>
 		</Reference>
-		<Reference Include="Unity.TextMeshPro">
-		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\Unity.TextMeshPro.dll</HintPath>
+		<Reference Include="Unity.TextMeshPro" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\Unity.TextMeshPro.dll</HintPath>
 		</Reference>
-		<Reference Include="UnityEngine.AnimationModule">
-		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+		<Reference Include="UnityEngine.AnimationModule" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\UnityEngine.AnimationModule.dll</HintPath>
 		</Reference>
-		<Reference Include="UnityEngine.AssetBundleModule">
-		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\UnityEngine.AssetBundleModule.dll</HintPath>
+		<Reference Include="UnityEngine.AssetBundleModule" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\UnityEngine.AssetBundleModule.dll</HintPath>
 		</Reference>
-		<Reference Include="UnityEngine.AudioModule">
-		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\UnityEngine.AudioModule.dll</HintPath>
+		<Reference Include="UnityEngine.AudioModule" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\UnityEngine.AudioModule.dll</HintPath>
 		</Reference>
-		<Reference Include="UnityEngine.CoreModule">
-		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+		<Reference Include="UnityEngine.CoreModule" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\UnityEngine.CoreModule.dll</HintPath>
 		</Reference>
-		<Reference Include="UnityEngine.UI">
-		  <HintPath>X:\SteamLibrary\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed\UnityEngine.UI.dll</HintPath>
-		</Reference>	
-		
+		<Reference Include="UnityEngine.UI" Condition="'$(PlateUpManagedDir)' != ''">
+			<HintPath>$(PlateUpManagedDir)\UnityEngine.UI.dll</HintPath>
+		</Reference>
+
 		<!-- Mod Dependencies: KitchenLib & PreferenceSystem -->
-		<Reference Include="0Harmony">
-		  <HintPath>X:\SteamLibrary\steamapps\workshop\content\1599600\2898033283\0Harmony.dll</HintPath>
+		<Reference Include="0Harmony" Condition="'$(PlateUpWorkshopDir)' != ''">
+			<HintPath>$(PlateUpWorkshopDir)\2898033283\0Harmony.dll</HintPath>
 		</Reference>
-		<Reference Include="KitchenPlatePatch">
-			<HintPath>X:\SteamLibrary\steamapps\workshop\content\1599600\3306089551\KitchenPlatePatch.dll</HintPath>
+		<Reference Include="KitchenPlatePatch" Condition="'$(PlateUpWorkshopDir)' != ''">
+			<HintPath>$(PlateUpWorkshopDir)\3306089551\KitchenPlatePatch.dll</HintPath>
 		</Reference>
-		<Reference Include="KitchenLib">
-			<HintPath>X:\SteamLibrary\steamapps\workshop\content\1599600\2898069883\KitchenLib-Workshop.dll</HintPath>
+		<Reference Include="KitchenLib" Condition="'$(PlateUpWorkshopDir)' != ''">
+			<HintPath>$(PlateUpWorkshopDir)\2898069883\KitchenLib-Workshop.dll</HintPath>
 		</Reference>
-		<Reference Include="PreferenceSystem-Workshop">
-			<HintPath>X:\SteamLibrary\steamapps\workshop\content\1599600\2949018507\PreferenceSystem-Workshop.dll</HintPath>
+		<Reference Include="PreferenceSystem-Workshop" Condition="'$(PlateUpWorkshopDir)' != ''">
+			<HintPath>$(PlateUpWorkshopDir)\2949018507\PreferenceSystem-Workshop.dll</HintPath>
 		</Reference>
 	</ItemGroup>
+
+	<Target Name="EnsurePlateUpManagedDir" BeforeTargets="ResolveReferences" Condition="'$(PlateUpManagedDir)' == ''">
+		<Error Text="PlateUpManagedDir is not defined. Copy Directory.Build.props.sample to Directory.Build.props and set the path to PlateUp\PlateUp_Data\Managed." />
+	</Target>
+
+	<Target Name="EnsurePlateUpWorkshopDir" BeforeTargets="ResolveReferences" Condition="'$(PlateUpWorkshopDir)' == ''">
+		<Error Text="PlateUpWorkshopDir is not defined. Copy Directory.Build.props.sample to Directory.Build.props and set the path to your Steam workshop content directory." />
+	</Target>
 
 	<ItemGroup>
 		<Compile Remove="UnityProject - MysteryMeat\**" />

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# MysteryMeat
+
+## Local build setup
+
+1. Install [PlateUp!](https://store.steampowered.com/app/1599600/PlateUp/) through Steam so the managed game assemblies and workshop content are available locally.
+2. Copy `Directory.Build.props.sample` to `Directory.Build.props` in the repository root. The real file stays untracked so each developer can point to their own install.
+3. Edit `Directory.Build.props` and set the following properties to match your machine:
+   - `<PlateUpManagedDir>` should point at the game's managed assemblies folder, e.g. `C:\Program Files (x86)\Steam\steamapps\common\PlateUp\PlateUp\PlateUp_Data\Managed` on Windows.
+   - `<PlateUpWorkshopDir>` should point at Steam's workshop content directory for PlateUp!, e.g. `C:\Program Files (x86)\Steam\steamapps\workshop\content99600`.
+4. Build the solution with `dotnet build MysteryMeat.sln`.
+
+The build will emit a clear error if either property is missing so you know to update your configuration.
+
+## Required workshop packages
+
+The project expects the following workshop items to exist under `$(PlateUpWorkshopDir)`:
+
+- `2898033283` – Harmony (`0Harmony.dll`)
+- `3306089551` – KitchenPlatePatch (`KitchenPlatePatch.dll`)
+- `2898069883` – KitchenLib (`KitchenLib-Workshop.dll`)
+- `2949018507` – PreferenceSystem (`PreferenceSystem-Workshop.dll`)
+
+You can find these IDs in Steam by opening each mod's workshop page and copying the trailing number from the URL. Once Steam has downloaded them, ensure the directory names above exist beneath your configured `PlateUpWorkshopDir`.


### PR DESCRIPTION
## Summary
- add a Directory.Build.props.sample template and ignore the real Directory.Build.props so each contributor can configure their own PlateUp paths
- refactor MysteryMeat.csproj references to use PlateUpManagedDir and PlateUpWorkshopDir properties with guard targets for missing configuration
- document how to populate Directory.Build.props and locate the required PlateUp files in a new README

## Testing
- not run (PlateUp game files are not available in the container environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce78b69570832e979c8fc61cab0559