### PR TITLE
Ensure persistent corpses stay on held appliances

### DIFF
--- a/Components/CIllegalSightHolderPreserved.cs
+++ b/Components/CIllegalSightHolderPreserved.cs
@@ -1,0 +1,9 @@
+using KitchenMods;
+
+namespace KitchenMysteryMeat.Components
+{
+    public struct CIllegalSightHolderPreserved : IModComponent
+    {
+        public bool AddedPreserver;
+    }
+}

--- a/Systems/ApplyIllegalSightOvernightFlags.cs
+++ b/Systems/ApplyIllegalSightOvernightFlags.cs
@@ -1,5 +1,4 @@
 using Kitchen;
-using KitchenData;
 using KitchenLib.Utils;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
@@ -35,48 +34,19 @@ namespace KitchenMysteryMeat.Systems
 
             HashSet<Entity> holdersWithIllegalItems = persistent ? new HashSet<Entity>() : null;
 
-            using NativeArray<Entity> illegals = IllegalEntities.ToEntityArray(Allocator.Temp);
-            for (int i = 0; i < illegals.Length; ++i)
+            if (persistent)
             {
-                Entity entity = illegals[i];
-                CIllegalSight illegal = EntityManager.GetComponentData<CIllegalSight>(entity);
-                bool canTurn = illegal.TurnIntoOnDayStart > 0;
-                bool hasPreservedFlag = EntityManager.HasComponent<CPreservedOvernight>(entity);
-
-                if (EntityManager.HasComponent<CItem>(entity))
+                using NativeArray<Entity> illegals = IllegalEntities.ToEntityArray(Allocator.Temp);
+                for (int i = 0; i < illegals.Length; ++i)
                 {
-                    if (persistent)
-                    {
-                        if (canTurn && !hasPreservedFlag)
-                        {
-                            EntityManager.AddComponentData(entity, new CPreservedOvernight());
-                            hasPreservedFlag = true;
-                        }
+                    Entity entity = illegals[i];
 
-                        if ((canTurn || hasPreservedFlag) && holdersWithIllegalItems != null)
-                        {
-                            HandleHeldItemPreservation(entity, holdersWithIllegalItems);
-                        }
-                    }
-                    else if (canTurn && hasPreservedFlag)
+                    if (!EntityManager.HasComponent<CItem>(entity))
                     {
-                        EntityManager.RemoveComponent<CPreservedOvernight>(entity);
+                        continue;
                     }
-                }
 
-                if (EntityManager.HasComponent<CAppliance>(entity))
-                {
-                    if (persistent)
-                    {
-                        if (EntityManager.HasComponent<CDestroyApplianceAtNight>(entity))
-                        {
-                            EntityManager.RemoveComponent<CDestroyApplianceAtNight>(entity);
-                        }
-                    }
-                    else if (canTurn && !EntityManager.HasComponent<CDestroyApplianceAtNight>(entity))
-                    {
-                        EntityManager.AddComponentData(entity, new CDestroyApplianceAtNight());
-                    }
+                    HandleHeldItemPreservation(entity, holdersWithIllegalItems);
                 }
             }
 

--- a/Systems/ApplyIllegalSightOvernightFlags.cs
+++ b/Systems/ApplyIllegalSightOvernightFlags.cs
@@ -3,6 +3,7 @@ using KitchenData;
 using KitchenLib.Utils;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
+using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Entities;
 
@@ -11,6 +12,7 @@ namespace KitchenMysteryMeat.Systems
     public class ApplyIllegalSightOvernightFlags : GameSystemBase, IModSystem
     {
         private EntityQuery IllegalEntities;
+        private EntityQuery HolderPreservers;
 
         protected override void Initialise()
         {
@@ -20,34 +22,43 @@ namespace KitchenMysteryMeat.Systems
             {
                 All = new[] { ComponentType.ReadOnly<CIllegalSight>() }
             });
+
+            HolderPreservers = GetEntityQuery(new EntityQueryDesc
+            {
+                All = new[] { ComponentType.ReadOnly<CIllegalSightHolderPreserved>() }
+            });
         }
 
         protected override void OnUpdate()
         {
             bool persistent = HasStatus((RestaurantStatus)VariousUtils.GetID("persistentcorpses"));
 
-            using NativeArray<Entity> illegals = IllegalEntities.ToEntityArray(Allocator.Temp);
-            if (illegals.Length == 0)
-                return;
+            HashSet<Entity> holdersWithIllegalItems = persistent ? new HashSet<Entity>() : null;
 
+            using NativeArray<Entity> illegals = IllegalEntities.ToEntityArray(Allocator.Temp);
             for (int i = 0; i < illegals.Length; ++i)
             {
                 Entity entity = illegals[i];
                 CIllegalSight illegal = EntityManager.GetComponentData<CIllegalSight>(entity);
-
-                if (illegal.TurnIntoOnDayStart <= 0)
-                    continue;
+                bool canTurn = illegal.TurnIntoOnDayStart > 0;
+                bool hasPreservedFlag = EntityManager.HasComponent<CPreservedOvernight>(entity);
 
                 if (EntityManager.HasComponent<CItem>(entity))
                 {
                     if (persistent)
                     {
-                        if (!EntityManager.HasComponent<CPreservedOvernight>(entity))
+                        if (canTurn && !hasPreservedFlag)
                         {
                             EntityManager.AddComponentData(entity, new CPreservedOvernight());
+                            hasPreservedFlag = true;
+                        }
+
+                        if ((canTurn || hasPreservedFlag) && holdersWithIllegalItems != null)
+                        {
+                            HandleHeldItemPreservation(entity, holdersWithIllegalItems);
                         }
                     }
-                    else if (EntityManager.HasComponent<CPreservedOvernight>(entity))
+                    else if (canTurn && hasPreservedFlag)
                     {
                         EntityManager.RemoveComponent<CPreservedOvernight>(entity);
                     }
@@ -62,11 +73,80 @@ namespace KitchenMysteryMeat.Systems
                             EntityManager.RemoveComponent<CDestroyApplianceAtNight>(entity);
                         }
                     }
-                    else if (!EntityManager.HasComponent<CDestroyApplianceAtNight>(entity))
+                    else if (canTurn && !EntityManager.HasComponent<CDestroyApplianceAtNight>(entity))
                     {
                         EntityManager.AddComponentData(entity, new CDestroyApplianceAtNight());
                     }
                 }
+            }
+
+            CleanupHolderPreservers(persistent, holdersWithIllegalItems);
+        }
+
+        private void HandleHeldItemPreservation(Entity item, HashSet<Entity> holdersWithIllegalItems)
+        {
+            if (holdersWithIllegalItems == null)
+                return;
+
+            if (!EntityManager.HasComponent<CHeldBy>(item))
+                return;
+
+            CHeldBy heldBy = EntityManager.GetComponentData<CHeldBy>(item);
+            Entity holder = heldBy.Holder;
+
+            if (holder == Entity.Null || !EntityManager.HasComponent<CAppliance>(holder))
+                return;
+
+            holdersWithIllegalItems.Add(holder);
+
+            bool hadPreserver = EntityManager.HasComponent<CPreservesContentsOvernight>(holder);
+            if (!hadPreserver)
+            {
+                EntityManager.AddComponentData(holder, new CPreservesContentsOvernight());
+            }
+
+            if (EntityManager.HasComponent<CIllegalSightHolderPreserved>(holder))
+            {
+                if (!hadPreserver)
+                {
+                    CIllegalSightHolderPreserved marker = EntityManager.GetComponentData<CIllegalSightHolderPreserved>(holder);
+                    if (!marker.AddedPreserver)
+                    {
+                        marker.AddedPreserver = true;
+                        EntityManager.SetComponentData(holder, marker);
+                    }
+                }
+            }
+            else
+            {
+                EntityManager.AddComponentData(holder, new CIllegalSightHolderPreserved
+                {
+                    AddedPreserver = !hadPreserver
+                });
+            }
+        }
+
+        private void CleanupHolderPreservers(bool persistent, HashSet<Entity> holdersWithIllegalItems)
+        {
+            using NativeArray<Entity> holders = HolderPreservers.ToEntityArray(Allocator.Temp);
+            if (holders.Length == 0)
+                return;
+
+            for (int i = holders.Length - 1; i >= 0; --i)
+            {
+                Entity holder = holders[i];
+
+                if (persistent && holdersWithIllegalItems != null && holdersWithIllegalItems.Contains(holder))
+                    continue;
+
+                CIllegalSightHolderPreserved marker = EntityManager.GetComponentData<CIllegalSightHolderPreserved>(holder);
+
+                if (marker.AddedPreserver && EntityManager.HasComponent<CPreservesContentsOvernight>(holder))
+                {
+                    EntityManager.RemoveComponent<CPreservesContentsOvernight>(holder);
+                }
+
+                EntityManager.RemoveComponent<CIllegalSightHolderPreserved>(holder);
             }
         }
     }

--- a/Systems/ApplyIllegalSightOvernightFlags.cs
+++ b/Systems/ApplyIllegalSightOvernightFlags.cs
@@ -1,4 +1,5 @@
 using Kitchen;
+using KitchenData;
 using KitchenLib.Utils;
 using KitchenMods;
 using KitchenMysteryMeat.Components;

--- a/Systems/ApplyIllegalSightOvernightFlags.cs
+++ b/Systems/ApplyIllegalSightOvernightFlags.cs
@@ -35,20 +35,17 @@ namespace KitchenMysteryMeat.Systems
 
             HashSet<Entity> holdersWithIllegalItems = persistent ? new HashSet<Entity>() : null;
 
-            if (persistent)
+            using NativeArray<Entity> illegals = IllegalEntities.ToEntityArray(Allocator.Temp);
+            for (int i = 0; i < illegals.Length; ++i)
             {
-                using NativeArray<Entity> illegals = IllegalEntities.ToEntityArray(Allocator.Temp);
-                for (int i = 0; i < illegals.Length; ++i)
+                Entity entity = illegals[i];
+
+                if (persistent && EntityManager.HasComponent<CItem>(entity))
                 {
-                    Entity entity = illegals[i];
-
-                    if (!EntityManager.HasComponent<CItem>(entity))
-                    {
-                        continue;
-                    }
-
                     HandleHeldItemPreservation(entity, holdersWithIllegalItems);
                 }
+
+                HandleApplianceOvernightBehaviour(entity, persistent);
             }
 
             CleanupHolderPreservers(persistent, holdersWithIllegalItems);
@@ -118,6 +115,31 @@ namespace KitchenMysteryMeat.Systems
                 }
 
                 EntityManager.RemoveComponent<CIllegalSightHolderPreserved>(holder);
+            }
+        }
+
+        private void HandleApplianceOvernightBehaviour(Entity entity, bool persistent)
+        {
+            if (!EntityManager.HasComponent<CAppliance>(entity))
+            {
+                return;
+            }
+
+            bool hasDestroyMarker = EntityManager.HasComponent<CDestroyApplianceAtNight>(entity);
+
+            if (persistent)
+            {
+                if (hasDestroyMarker)
+                {
+                    EntityManager.RemoveComponent<CDestroyApplianceAtNight>(entity);
+                }
+
+                return;
+            }
+
+            if (!hasDestroyMarker)
+            {
+                EntityManager.AddComponentData(entity, new CDestroyApplianceAtNight());
             }
         }
     }


### PR DESCRIPTION
## Summary
- add a component marker to track appliances that temporarily preserve illegal sights
- keep counters and other holders flagged to preserve corpses while Persistent Corpses is active
- remove the temporary preservation marker when the effect is disabled or the corpse is removed

## Testing
- `dotnet build` *(fails: `dotnet` is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf451b484c832eb783b8fe8e33366b