### PR TITLE
Conditionally keep destroy marker for illegal appliances

### DIFF
--- a/Systems/ApplyIllegalSightOvernightFlags.cs
+++ b/Systems/ApplyIllegalSightOvernightFlags.cs
@@ -129,9 +129,15 @@ namespace KitchenMysteryMeat.Systems
 
             if (persistent)
             {
-                if (hasDestroyMarker)
+                CIllegalSight illegalSight = EntityManager.GetComponentData<CIllegalSight>(entity);
+                bool transformsOnDayStart = illegalSight.TurnIntoOnDayStart > 0;
+
+                if (transformsOnDayStart)
                 {
-                    EntityManager.RemoveComponent<CDestroyApplianceAtNight>(entity);
+                    if (hasDestroyMarker)
+                    {
+                        EntityManager.RemoveComponent<CDestroyApplianceAtNight>(entity);
+                    }
                 }
 
                 return;


### PR DESCRIPTION
## Summary
- only remove CDestroyApplianceAtNight when the illegal sight component transforms on day start
- keep mess appliances flagged for destruction so they follow normal overnight cleanup

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cf577c98b4832e884b38dffe748689