### PR TITLE
Skip invalid conversions without stopping loop

### DIFF
--- a/Systems/TurnItemsIntoOthers.cs
+++ b/Systems/TurnItemsIntoOthers.cs
@@ -34,7 +34,7 @@ namespace KitchenMysteryMeat.Systems
 
                 if (cTurnIntoItem.NewID == 0)
                 {
-                    return;
+                    continue;
                 }
                 EntityManager.AddComponentData<CChangeItemType>(item, new CChangeItemType()
                 {


### PR DESCRIPTION
## Summary
- skip only invalid conversion targets in TurnItemsIntoOthers so the rest of the loop continues

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf710e70dc832ea61991d97a25e079