### PR TITLE
Ensure automated poisoners iterate over all targets

### DIFF
--- a/Systems/CombinerPoisonInteraction.cs
+++ b/Systems/CombinerPoisonInteraction.cs
@@ -45,17 +45,17 @@ namespace KitchenMysteryMeat.Systems
                 CAutomatedInteractorRandomActiveInterval cautomatedInteractorRandomActiveInterval;
                 if (base.Require<CAutomatedInteractorRandomActiveInterval>(automatedInteractor, out cautomatedInteractorRandomActiveInterval) && !cautomatedInteractorRandomActiveInterval.Active)
                 {
-                    return;
+                    continue;
                 }
                 Vector3 forwardPosition = position.ForwardPosition;
                 Entity occupant = TileManager.GetOccupant(forwardPosition, OccupancyLayer.Default);
                 if (!TileManager.CanReach(position, forwardPosition, false))
                 {
-                    return;
+                    continue;
                 }
                 if (occupant == default(Entity))
                 {
-                    return;
+                    continue;
                 }
                 EntityManager.AddComponentData<CAttemptingInteraction>(automatedInteractor, new CAttemptingInteraction
                 {


### PR DESCRIPTION
## Summary
- update the combiner poison interaction to skip invalid automated interactors without aborting the remaining iterations

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf73bfd630832ea5cf6f3c638febc0