### PR TITLE
Handle preserved holders added by mod

### DIFF
--- a/Systems/ApplyIllegalSightEffects.cs
+++ b/Systems/ApplyIllegalSightEffects.cs
@@ -63,7 +63,7 @@ namespace KitchenMysteryMeat.Systems
                 TryTransformHeldEntity(ctx, holder.HeldItem, processedItems);
             }
 
-            if (EntityManager.HasBuffer<CItemStored>(appliance))
+            if (EntityManager.HasComponent<CItemStored>(appliance))
             {
                 DynamicBuffer<CItemStored> storedItems = EntityManager.GetBuffer<CItemStored>(appliance);
                 for (int i = 0; i < storedItems.Length; i++)

--- a/Systems/ApplyIllegalSightEffects.cs
+++ b/Systems/ApplyIllegalSightEffects.cs
@@ -15,23 +15,54 @@ namespace KitchenMysteryMeat.Systems
 {
     public class ApplyIllegalSightEffects : StartOfDaySystem, IModSystem
     {
-        protected override void OnUpdate()
+        private EntityQuery IllegalQuery;
+        private EntityQuery ApplianceHolderQuery;
+        private EntityQuery ApplianceStorageQuery;
+
+        protected override void Initialise()
         {
-            // Build query of illegal entities
-            var query = GetEntityQuery(new EntityQueryDesc
+            base.Initialise();
+
+            IllegalQuery = GetEntityQuery(new EntityQueryDesc
             {
                 All = new[] { ComponentType.ReadOnly<CIllegalSight>() }
             });
 
-            using (NativeArray<Entity> illegals = query.ToEntityArray(Allocator.Temp))
+            ApplianceHolderQuery = GetEntityQuery(new EntityQueryDesc
             {
-                if (illegals.Length == 0)
-                    return;
+                All = new[]
+                {
+                    ComponentType.ReadOnly<CAppliance>(),
+                    ComponentType.ReadOnly<CItemHolder>()
+                }
+            });
 
-                // Create an EntityContext backed by the project's EntityManager
-                EntityContext ctx = new EntityContext(EntityManager);
-                HashSet<Entity> processedItems = new HashSet<Entity>();
+            ApplianceStorageQuery = GetEntityQuery(new EntityQueryDesc
+            {
+                All = new[]
+                {
+                    ComponentType.ReadOnly<CAppliance>(),
+                    ComponentType.ReadOnly<CItemStored>()
+                }
+            });
+        }
 
+        protected override void OnUpdate()
+        {
+            bool hasIllegalItems = !IllegalQuery.IsEmptyIgnoreFilter;
+            bool hasHolders = !ApplianceHolderQuery.IsEmptyIgnoreFilter;
+            bool hasStorage = !ApplianceStorageQuery.IsEmptyIgnoreFilter;
+
+            if (!hasIllegalItems && !hasHolders && !hasStorage)
+                return;
+
+            // Create an EntityContext backed by the project's EntityManager
+            EntityContext ctx = new EntityContext(EntityManager);
+            HashSet<Entity> processedItems = new HashSet<Entity>();
+
+            if (hasIllegalItems)
+            {
+                using NativeArray<Entity> illegals = IllegalQuery.ToEntityArray(Allocator.Temp);
                 for (int i = illegals.Length - 1; i >= 0; --i)
                 {
                     Entity e = illegals[i];
@@ -48,6 +79,41 @@ namespace KitchenMysteryMeat.Systems
                         ProcessApplianceSurfaceContents(ctx, e, processedItems);
                         CorpseEffects.ReplaceWithAppliance(ctx, e);
                     }
+                }
+            }
+
+            if (hasHolders)
+            {
+                ProcessAllItemHolders(ctx, processedItems);
+            }
+
+            if (hasStorage)
+            {
+                ProcessAllStoredItems(ctx, processedItems);
+            }
+        }
+
+        private void ProcessAllItemHolders(EntityContext ctx, HashSet<Entity> processedItems)
+        {
+            using NativeArray<Entity> holders = ApplianceHolderQuery.ToEntityArray(Allocator.Temp);
+            for (int i = holders.Length - 1; i >= 0; --i)
+            {
+                Entity appliance = holders[i];
+                CItemHolder holder = EntityManager.GetComponentData<CItemHolder>(appliance);
+                TryTransformHeldEntity(ctx, holder.HeldItem, processedItems);
+            }
+        }
+
+        private void ProcessAllStoredItems(EntityContext ctx, HashSet<Entity> processedItems)
+        {
+            using NativeArray<Entity> storages = ApplianceStorageQuery.ToEntityArray(Allocator.Temp);
+            for (int i = storages.Length - 1; i >= 0; --i)
+            {
+                Entity appliance = storages[i];
+                DynamicBuffer<CItemStored> storedItems = EntityManager.GetBuffer<CItemStored>(appliance);
+                for (int j = 0; j < storedItems.Length; j++)
+                {
+                    TryTransformHeldEntity(ctx, storedItems[j].StoredItem, processedItems);
                 }
             }
         }
@@ -76,6 +142,9 @@ namespace KitchenMysteryMeat.Systems
         private void TryTransformHeldEntity(EntityContext ctx, Entity heldItem, HashSet<Entity> processedItems)
         {
             if (heldItem == Entity.Null || !EntityManager.Exists(heldItem))
+                return;
+
+            if (!ctx.Has<CIllegalSight>(heldItem))
                 return;
 
             if (!processedItems.Add(heldItem))

--- a/Systems/ApplyIllegalSightEffects.cs
+++ b/Systems/ApplyIllegalSightEffects.cs
@@ -7,6 +7,7 @@ using Kitchen;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Systems.Effects;
+using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Entities;
 
@@ -24,26 +25,63 @@ namespace KitchenMysteryMeat.Systems
 
             using (NativeArray<Entity> illegals = query.ToEntityArray(Allocator.Temp))
             {
-                if (illegals.Length > 0)
+                if (illegals.Length == 0)
+                    return;
+
+                // Create an EntityContext backed by the project's EntityManager
+                EntityContext ctx = new EntityContext(EntityManager);
+                HashSet<Entity> processedItems = new HashSet<Entity>();
+
+                for (int i = illegals.Length - 1; i >= 0; --i)
                 {
-                    // Create an EntityContext backed by the project's EntityManager
-                    EntityContext ctx = new EntityContext(EntityManager);
+                    Entity e = illegals[i];
 
-                    for (int i = illegals.Length - 1; i >= 0; --i)
+                    if (ctx.Has<CItem>(e))
                     {
-                        Entity e = illegals[i];
-
-                        if (ctx.Has<CItem>(e))
+                        if (processedItems.Add(e))
                         {
                             CorpseEffects.TransformCorpse(ctx, e);
                         }
-                        else if (ctx.Has<CAppliance>(e))
-                        {
-                            CorpseEffects.ReplaceWithAppliance(ctx, e);
-                        }
+                    }
+                    else if (ctx.Has<CAppliance>(e))
+                    {
+                        ProcessApplianceSurfaceContents(ctx, e, processedItems);
+                        CorpseEffects.ReplaceWithAppliance(ctx, e);
                     }
                 }
             }
+        }
+
+        private void ProcessApplianceSurfaceContents(EntityContext ctx, Entity appliance, HashSet<Entity> processedItems)
+        {
+            if (processedItems == null)
+                return;
+
+            if (EntityManager.HasComponent<CItemHolder>(appliance))
+            {
+                CItemHolder holder = EntityManager.GetComponentData<CItemHolder>(appliance);
+                TryTransformHeldEntity(ctx, holder.HeldItem, processedItems);
+            }
+
+            if (EntityManager.HasBuffer<CItemStored>(appliance))
+            {
+                DynamicBuffer<CItemStored> storedItems = EntityManager.GetBuffer<CItemStored>(appliance);
+                for (int i = 0; i < storedItems.Length; i++)
+                {
+                    TryTransformHeldEntity(ctx, storedItems[i].StoredItem, processedItems);
+                }
+            }
+        }
+
+        private void TryTransformHeldEntity(EntityContext ctx, Entity heldItem, HashSet<Entity> processedItems)
+        {
+            if (heldItem == Entity.Null || !EntityManager.Exists(heldItem))
+                return;
+
+            if (!processedItems.Add(heldItem))
+                return;
+
+            CorpseEffects.TransformCorpse(ctx, heldItem);
         }
     }
 }

--- a/Systems/Effects/Effect_TransformCorpse.cs
+++ b/Systems/Effects/Effect_TransformCorpse.cs
@@ -31,16 +31,16 @@ namespace KitchenMysteryMeat.Systems.Effects
 
                 if (holderEntity != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holderEntity))
                 {
-                    bool addedPreserver = false;
+                    bool shouldSkip = false;
 
                     if (ctx.Has<CIllegalSightHolderPreserved>(holderEntity))
                     {
                         CIllegalSightHolderPreserved marker = ctx.Get<CIllegalSightHolderPreserved>(holderEntity);
-                        addedPreserver = marker.AddedPreserver;
+                        shouldSkip = !marker.AddedPreserver;
                     }
 
                     // Only skip transforming if the holder already preserved contents before our systems intervened.
-                    if (!addedPreserver)
+                    if (shouldSkip)
                         return;
                 }
             }

--- a/Systems/Effects/Effect_TransformCorpse.cs
+++ b/Systems/Effects/Effect_TransformCorpse.cs
@@ -31,16 +31,14 @@ namespace KitchenMysteryMeat.Systems.Effects
 
                 if (holderEntity != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holderEntity))
                 {
-                    bool shouldSkip = false;
+                    bool hasMarker = ctx.Has<CIllegalSightHolderPreserved>(holderEntity);
 
-                    if (ctx.Has<CIllegalSightHolderPreserved>(holderEntity))
-                    {
-                        CIllegalSightHolderPreserved marker = ctx.Get<CIllegalSightHolderPreserved>(holderEntity);
-                        shouldSkip = !marker.AddedPreserver;
-                    }
+                    if (!hasMarker)
+                        return;
 
-                    // Only skip transforming if the holder already preserved contents before our systems intervened.
-                    if (shouldSkip)
+                    CIllegalSightHolderPreserved marker = ctx.Get<CIllegalSightHolderPreserved>(holderEntity);
+
+                    if (!marker.AddedPreserver)
                         return;
                 }
             }

--- a/Systems/Effects/Effect_TransformCorpse.cs
+++ b/Systems/Effects/Effect_TransformCorpse.cs
@@ -27,10 +27,21 @@ namespace KitchenMysteryMeat.Systems.Effects
             if (ctx.Has<CHeldBy>(entity))
             {
                 CHeldBy holder = ctx.Get<CHeldBy>(entity);
-                if (holder.Holder != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holder.Holder))
+                Entity holderEntity = holder.Holder;
+
+                if (holderEntity != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holderEntity))
                 {
-                    // Holder preserves contents — do nothing.
-                    return;
+                    bool addedPreserver = false;
+
+                    if (ctx.Has<CIllegalSightHolderPreserved>(holderEntity))
+                    {
+                        CIllegalSightHolderPreserved marker = ctx.Get<CIllegalSightHolderPreserved>(holderEntity);
+                        addedPreserver = marker.AddedPreserver;
+                    }
+
+                    // Only skip transforming if the holder already preserved contents before our systems intervened.
+                    if (!addedPreserver)
+                        return;
                 }
             }
 


### PR DESCRIPTION
## Summary
- continue transforming corpses when the overnight preserver was added by the mod
- leave the change-item marker assignment so rot conversion still occurs on day start

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf7aa2ef8c832ea5a5fb5a04a71636