### PR TITLE
Broaden corpse rot sweep to appliance holders

### DIFF
--- a/Systems/ApplyIllegalSightEffects.cs
+++ b/Systems/ApplyIllegalSightEffects.cs
@@ -7,6 +7,7 @@ using Kitchen;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Systems.Effects;
+using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Entities;
 
@@ -24,23 +25,105 @@ namespace KitchenMysteryMeat.Systems
 
             using (NativeArray<Entity> illegals = query.ToEntityArray(Allocator.Temp))
             {
-                if (illegals.Length > 0)
+                if (illegals.Length == 0)
+                    return;
+
+                // Create an EntityContext backed by the project's EntityManager
+                EntityContext ctx = new EntityContext(EntityManager);
+                HashSet<Entity> processedItems = new HashSet<Entity>();
+
+                // Ensure we catch corpses sitting on counters or stored overnight before
+                // we mutate any appliances. This sweeps every holder/storage entity so we
+                // do not rely on the illegal query hitting the held item directly.
+                ProcessGlobalIllegalHolders(ctx, processedItems);
+
+                for (int i = illegals.Length - 1; i >= 0; --i)
                 {
-                    // Create an EntityContext backed by the project's EntityManager
-                    EntityContext ctx = new EntityContext(EntityManager);
+                    Entity e = illegals[i];
 
-                    for (int i = illegals.Length - 1; i >= 0; --i)
+                    if (ctx.Has<CItem>(e))
                     {
-                        Entity e = illegals[i];
-
-                        if (ctx.Has<CItem>(e))
+                        if (processedItems.Add(e))
                         {
                             CorpseEffects.TransformCorpse(ctx, e);
                         }
-                        else if (ctx.Has<CAppliance>(e))
-                        {
-                            CorpseEffects.ReplaceWithAppliance(ctx, e);
-                        }
+                    }
+                    else if (ctx.Has<CAppliance>(e))
+                    {
+                        ProcessApplianceSurfaceContents(ctx, e, processedItems);
+                        CorpseEffects.ReplaceWithAppliance(ctx, e);
+                    }
+                }
+            }
+        }
+
+        private void ProcessApplianceSurfaceContents(EntityContext ctx, Entity appliance, HashSet<Entity> processedItems)
+        {
+            if (processedItems == null)
+                return;
+
+            if (EntityManager.HasComponent<CItemHolder>(appliance))
+            {
+                CItemHolder holder = EntityManager.GetComponentData<CItemHolder>(appliance);
+                TryTransformHeldEntity(ctx, holder.HeldItem, processedItems);
+            }
+
+            if (EntityManager.HasComponent<CItemStored>(appliance))
+            {
+                DynamicBuffer<CItemStored> storedItems = EntityManager.GetBuffer<CItemStored>(appliance);
+                for (int i = 0; i < storedItems.Length; i++)
+                {
+                    TryTransformHeldEntity(ctx, storedItems[i].StoredItem, processedItems);
+                }
+            }
+        }
+
+        private void TryTransformHeldEntity(EntityContext ctx, Entity heldItem, HashSet<Entity> processedItems)
+        {
+            if (heldItem == Entity.Null || !EntityManager.Exists(heldItem))
+                return;
+
+            if (!ctx.Has<CIllegalSight>(heldItem))
+                return;
+
+            if (!processedItems.Add(heldItem))
+                return;
+
+            CorpseEffects.TransformCorpse(ctx, heldItem);
+        }
+
+        private void ProcessGlobalIllegalHolders(EntityContext ctx, HashSet<Entity> processedItems)
+        {
+            if (processedItems == null)
+                return;
+
+            var holderQuery = GetEntityQuery(new EntityQueryDesc
+            {
+                All = new[] { ComponentType.ReadOnly<CItemHolder>() }
+            });
+
+            using (NativeArray<Entity> holders = holderQuery.ToEntityArray(Allocator.Temp))
+            using (NativeArray<CItemHolder> holderData = holderQuery.ToComponentDataArray<CItemHolder>(Allocator.Temp))
+            {
+                for (int i = holders.Length - 1; i >= 0; --i)
+                {
+                    TryTransformHeldEntity(ctx, holderData[i].HeldItem, processedItems);
+                }
+            }
+
+            var storageQuery = GetEntityQuery(new EntityQueryDesc
+            {
+                All = new[] { ComponentType.ReadOnly<CItemStored>() }
+            });
+
+            using (NativeArray<Entity> storages = storageQuery.ToEntityArray(Allocator.Temp))
+            {
+                for (int i = storages.Length - 1; i >= 0; --i)
+                {
+                    DynamicBuffer<CItemStored> storedItems = EntityManager.GetBuffer<CItemStored>(storages[i]);
+                    for (int j = 0; j < storedItems.Length; ++j)
+                    {
+                        TryTransformHeldEntity(ctx, storedItems[j].StoredItem, processedItems);
                     }
                 }
             }

--- a/Systems/Effects/Effect_TransformCorpse.cs
+++ b/Systems/Effects/Effect_TransformCorpse.cs
@@ -27,10 +27,19 @@ namespace KitchenMysteryMeat.Systems.Effects
             if (ctx.Has<CHeldBy>(entity))
             {
                 CHeldBy holder = ctx.Get<CHeldBy>(entity);
-                if (holder.Holder != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holder.Holder))
+                Entity holderEntity = holder.Holder;
+
+                if (holderEntity != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holderEntity))
                 {
-                    // Holder preserves contents — do nothing.
-                    return;
+                    bool hasMarker = ctx.Has<CIllegalSightHolderPreserved>(holderEntity);
+
+                    if (!hasMarker)
+                        return;
+
+                    CIllegalSightHolderPreserved marker = ctx.Get<CIllegalSightHolderPreserved>(holderEntity);
+
+                    if (!marker.AddedPreserver)
+                        return;
                 }
             }
 


### PR DESCRIPTION
## Summary
- sweep all appliance holders and storage buffers for illegal-sight items before the start-of-day conversion so counter corpses receive rot markers
- ensure the held-item scan only marks entities that actually carry CIllegalSight so legitimate items remain eligible for later processing

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf7aa2ef8c832ea5a5fb5a04a71636