### PR TITLE
Ensure corpse rot applies when holder lacks preservation marker

### DIFF
--- a/Systems/ApplyIllegalSightEffects.cs
+++ b/Systems/ApplyIllegalSightEffects.cs
@@ -7,6 +7,7 @@ using Kitchen;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Systems.Effects;
+using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Entities;
 
@@ -24,26 +25,63 @@ namespace KitchenMysteryMeat.Systems
 
             using (NativeArray<Entity> illegals = query.ToEntityArray(Allocator.Temp))
             {
-                if (illegals.Length > 0)
+                if (illegals.Length == 0)
+                    return;
+
+                // Create an EntityContext backed by the project's EntityManager
+                EntityContext ctx = new EntityContext(EntityManager);
+                HashSet<Entity> processedItems = new HashSet<Entity>();
+
+                for (int i = illegals.Length - 1; i >= 0; --i)
                 {
-                    // Create an EntityContext backed by the project's EntityManager
-                    EntityContext ctx = new EntityContext(EntityManager);
+                    Entity e = illegals[i];
 
-                    for (int i = illegals.Length - 1; i >= 0; --i)
+                    if (ctx.Has<CItem>(e))
                     {
-                        Entity e = illegals[i];
-
-                        if (ctx.Has<CItem>(e))
+                        if (processedItems.Add(e))
                         {
                             CorpseEffects.TransformCorpse(ctx, e);
                         }
-                        else if (ctx.Has<CAppliance>(e))
-                        {
-                            CorpseEffects.ReplaceWithAppliance(ctx, e);
-                        }
+                    }
+                    else if (ctx.Has<CAppliance>(e))
+                    {
+                        ProcessApplianceSurfaceContents(ctx, e, processedItems);
+                        CorpseEffects.ReplaceWithAppliance(ctx, e);
                     }
                 }
             }
+        }
+
+        private void ProcessApplianceSurfaceContents(EntityContext ctx, Entity appliance, HashSet<Entity> processedItems)
+        {
+            if (processedItems == null)
+                return;
+
+            if (EntityManager.HasComponent<CItemHolder>(appliance))
+            {
+                CItemHolder holder = EntityManager.GetComponentData<CItemHolder>(appliance);
+                TryTransformHeldEntity(ctx, holder.HeldItem, processedItems);
+            }
+
+            if (EntityManager.HasComponent<CItemStored>(appliance))
+            {
+                DynamicBuffer<CItemStored> storedItems = EntityManager.GetBuffer<CItemStored>(appliance);
+                for (int i = 0; i < storedItems.Length; i++)
+                {
+                    TryTransformHeldEntity(ctx, storedItems[i].StoredItem, processedItems);
+                }
+            }
+        }
+
+        private void TryTransformHeldEntity(EntityContext ctx, Entity heldItem, HashSet<Entity> processedItems)
+        {
+            if (heldItem == Entity.Null || !EntityManager.Exists(heldItem))
+                return;
+
+            if (!processedItems.Add(heldItem))
+                return;
+
+            CorpseEffects.TransformCorpse(ctx, heldItem);
         }
     }
 }

--- a/Systems/Effects/Effect_TransformCorpse.cs
+++ b/Systems/Effects/Effect_TransformCorpse.cs
@@ -27,10 +27,17 @@ namespace KitchenMysteryMeat.Systems.Effects
             if (ctx.Has<CHeldBy>(entity))
             {
                 CHeldBy holder = ctx.Get<CHeldBy>(entity);
-                if (holder.Holder != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holder.Holder))
+                Entity holderEntity = holder.Holder;
+
+                if (holderEntity != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holderEntity))
                 {
-                    // Holder preserves contents — do nothing.
-                    return;
+                    if (ctx.Has<CIllegalSightHolderPreserved>(holderEntity))
+                    {
+                        CIllegalSightHolderPreserved marker = ctx.Get<CIllegalSightHolderPreserved>(holderEntity);
+
+                        if (!marker.AddedPreserver)
+                            return;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- only skip corpse-to-rotten conversion when a preservation marker explicitly says we didn't add the overnight preserver
- allow counters and other holders without the mod's marker to convert their held corpses to rotten variants

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf7aa2ef8c832ea5a5fb5a04a71636