### PR TITLE
Allow temporary preservers to rot corpses

### DIFF
--- a/Systems/Effects/Effect_TransformCorpse.cs
+++ b/Systems/Effects/Effect_TransformCorpse.cs
@@ -29,8 +29,18 @@ namespace KitchenMysteryMeat.Systems.Effects
                 CHeldBy holder = ctx.Get<CHeldBy>(entity);
                 if (holder.Holder != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holder.Holder))
                 {
-                    // Holder preserves contents — do nothing.
-                    return;
+                    bool addedByOvernightSystem = false;
+                    if (ctx.Has<CIllegalSightHolderPreserved>(holder.Holder))
+                    {
+                        CIllegalSightHolderPreserved marker = ctx.Get<CIllegalSightHolderPreserved>(holder.Holder);
+                        addedByOvernightSystem = marker.AddedPreserver;
+                    }
+
+                    if (!addedByOvernightSystem)
+                    {
+                        // Holder preserves contents on its own — do nothing.
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- allow Effect_TransformCorpse to ignore temporary overnight preservers added by our system
- ensure countertops still rot corpses while appliances that naturally preserve contents keep blocking transformations

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6dfd32ec832e80fddd3a9b92f923