### PR TITLE
Allow corpses on temporary preservers to rot

### DIFF
--- a/Systems/Effects/Effect_TransformCorpse.cs
+++ b/Systems/Effects/Effect_TransformCorpse.cs
@@ -27,10 +27,22 @@ namespace KitchenMysteryMeat.Systems.Effects
             if (ctx.Has<CHeldBy>(entity))
             {
                 CHeldBy holder = ctx.Get<CHeldBy>(entity);
-                if (holder.Holder != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holder.Holder))
+                Entity holderEntity = holder.Holder;
+
+                if (holderEntity != Entity.Null && ctx.Has<CPreservesContentsOvernight>(holderEntity))
                 {
-                    // Holder preserves contents — do nothing.
-                    return;
+                    if (!ctx.Has<CIllegalSightHolderPreserved>(holderEntity))
+                    {
+                        // Holder preserves contents permanently — skip transformation.
+                        return;
+                    }
+
+                    CIllegalSightHolderPreserved marker = ctx.Get<CIllegalSightHolderPreserved>(holderEntity);
+                    if (!marker.AddedPreserver)
+                    {
+                        // Holder's preservation flag wasn't added by the overnight system — skip transformation.
+                        return;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- ensure corpse transformation ignores preservation flags that were added temporarily for illegal sight holders

## Testing
- not run (dotnet not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf6dfd32ec832e80fddd3a9b92f923