### PR TITLE
Handle held illegal items when replacing appliances

### DIFF
--- a/Systems/Effects/Effect_ReplaceWithAppliance.cs
+++ b/Systems/Effects/Effect_ReplaceWithAppliance.cs
@@ -32,11 +32,6 @@ namespace KitchenMysteryMeat.Systems.Effects
                 var holder = ctx.Get<CItemHolder>(entity);
                 heldEntity = holder.HeldItem;
             }
-            else if (ctx.Has<CHeldItem>(entity))
-            {
-                var held = ctx.Get<CHeldItem>(entity);
-                heldEntity = held.HeldItem;
-            }
 
             if (heldEntity != Entity.Null && ctx.Has<CIllegalSight>(heldEntity))
             {

--- a/Systems/Effects/Effect_ReplaceWithAppliance.cs
+++ b/Systems/Effects/Effect_ReplaceWithAppliance.cs
@@ -25,6 +25,24 @@ namespace KitchenMysteryMeat.Systems.Effects
             if (illegal.TurnIntoOnDayStart <= 0)
                 return;
 
+            Entity heldEntity = Entity.Null;
+
+            if (ctx.Has<CItemHolder>(entity))
+            {
+                var holder = ctx.Get<CItemHolder>(entity);
+                heldEntity = holder.HeldItem;
+            }
+            else if (ctx.Has<CHeldItem>(entity))
+            {
+                var held = ctx.Get<CHeldItem>(entity);
+                heldEntity = held.HeldItem;
+            }
+
+            if (heldEntity != Entity.Null && ctx.Has<CIllegalSight>(heldEntity))
+            {
+                TransformCorpse(ctx, heldEntity);
+            }
+
             // Create new appliance entity
             Entity newEntity = ctx.CreateEntity();
             ctx.Set(newEntity, new CCreateAppliance


### PR DESCRIPTION
## Summary
- transform corpses held by appliances before replacing them overnight

## Testing
- `dotnet build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d08b95c898832ea2303c21e398f689