### PR TITLE
Swap held corpses with rotten variants

### DIFF
--- a/Systems/Effects/Effect_TransformCorpse.cs
+++ b/Systems/Effects/Effect_TransformCorpse.cs
@@ -12,44 +12,110 @@ namespace KitchenMysteryMeat.Systems.Effects
 {
     public static partial class CorpseEffects
     {
+        // Coordinates the corpse transformation process for any entity flagged with illegal sight.
         public static void TransformCorpse(EntityContext ctx, Entity entity)
         {
-            // If this is a corpse on an appliance
+            // Handle corpses that are currently held by another entity (for example, a counter).
             if (ctx.Has<CHeldBy>(entity))
             {
                 QueueUnpreservedCorpses(ctx, entity);
             }
             else
             {
-                // The Corpse Item itself
+                // Process standalone corpse items that should decay in place.
                 if (ctx.Has<CItem>(entity))
                 {
                     QueueCorpseTransformation(ctx, entity);
                 }
-                else // Corpse on the ground
+                else
                 {
+                    // Replace appliance corpses that exist as map objects rather than items.
                     ReplaceApplianceCorpses(ctx, entity);
                 }
             }
         }
 
-        private static void QueueUnpreservedCorpses (EntityContext ctx, Entity entity)
+        // Handles corpse items that are stored by another entity so they can decay correctly.
+        private static void QueueUnpreservedCorpses(EntityContext ctx, Entity entity)
         {
-            Entity holderEntity = ctx.Get<CHeldBy>(entity).Holder;
-            if (holderEntity != Entity.Null)
+            // Retrieve the current holder so we know where the corpse is stored.
+            CHeldBy heldBy = ctx.Get<CHeldBy>(entity);
+            Entity holderEntity = heldBy.Holder;
+
+            // If there is no holder we can fall back to the standard item transformation behaviour.
+            if (holderEntity == Entity.Null)
             {
-                if (!ctx.Has<CPreservesContentsOvernight>(holderEntity))
-                {
-                    QueueCorpseTransformation(ctx, entity); // In a container, but it's not a preserving one.
-                }
+                QueueCorpseTransformation(ctx, entity);
             }
             else
             {
-                QueueCorpseTransformation(ctx, entity); // OR Not in any container at all.
+                // Respect containers that preserve contents overnight by leaving the corpse untouched.
+                if (!ctx.Has<CPreservesContentsOvernight>(holderEntity))
+                {
+                    SwapCorpseWithRottenVersion(ctx, entity, holderEntity, heldBy);
+                }
             }
         }
 
+        // Creates a rotten corpse item while keeping the existing portion count and swaps it into the holder.
+        private static void SwapCorpseWithRottenVersion(EntityContext ctx, Entity corpseEntity, Entity holderEntity, CHeldBy heldBy)
+        {
+            // Determine what the corpse should become when it rots.
+            CIllegalSight illegalSight = ctx.Get<CIllegalSight>(corpseEntity);
+            int rottenCorpseID = illegalSight.TurnIntoOnDayStart;
 
+            // Only perform the swap if we have a valid rotten corpse to create.
+            if (rottenCorpseID <= 0)
+            {
+                return;
+            }
+
+            // Track how many portions remain so the new corpse can inherit the same amount.
+            CPersistPortions persistPortions = default;
+            bool hasPersistingPortions = false;
+            if (ctx.Has<CSplittableItem>(corpseEntity))
+            {
+                CSplittableItem split = ctx.Get<CSplittableItem>(corpseEntity);
+                persistPortions = new CPersistPortions
+                {
+                    RemainingCount = split.RemainingCount,
+                    TotalCount = split.TotalCount
+                };
+                hasPersistingPortions = true;
+            }
+
+            // Create a new entity that will become the rotten corpse held by the same container.
+            Entity rottenCorpseEntity = ctx.CreateEntity();
+            ctx.Set(rottenCorpseEntity, new CCreateItem
+            {
+                ID = rottenCorpseID,
+                Holder = holderEntity
+            });
+            ctx.Set(rottenCorpseEntity, heldBy);
+
+            // Preserve splittable data so partially used corpses remain partially used after rotting.
+            if (hasPersistingPortions)
+            {
+                ctx.Set(rottenCorpseEntity, persistPortions);
+            }
+
+            // Ensure the holder now references the rotten corpse instead of the fresh corpse.
+            if (ctx.Has<CItemHolder>(holderEntity))
+            {
+                CItemHolder itemHolder = ctx.Get<CItemHolder>(holderEntity);
+                // Only swap the reference when the holder is still pointing at the original corpse.
+                if (itemHolder.HeldItem == corpseEntity)
+                {
+                    itemHolder.HeldItem = rottenCorpseEntity;
+                    ctx.Set(holderEntity, itemHolder);
+                }
+            }
+
+            // Remove the original corpse because the rotten replacement has taken its place.
+            ctx.Destroy(corpseEntity);
+        }
+
+        // Queues the default corpse transformation on entities that can simply change their item type.
         private static void QueueCorpseTransformation(EntityContext ctx, Entity entity)
         {
             CIllegalSight illegalSight = ctx.Get<CIllegalSight>(entity);
@@ -72,11 +138,13 @@ namespace KitchenMysteryMeat.Systems.Effects
             }
         }
 
+        // Replaces corpse appliances placed directly in the world with their rotten variants.
         private static void ReplaceApplianceCorpses(EntityContext ctx, Entity entity)
         {
             CIllegalSight illegal = ctx.Get<CIllegalSight>(entity);
             CPosition pos = ctx.Get<CPosition>(entity);
 
+            // Only attempt to replace the appliance if the data specifies a rotten version.
             if (illegal.TurnIntoOnDayStart > 0)
             {
 


### PR DESCRIPTION
## Summary
- add a held-corpse swap that creates a rotten replacement while preserving remaining portions
- avoid transforming corpses kept inside preserving containers and keep appliance replacement logic intact

## Testing
- not run (environment only includes source files)

------
https://chatgpt.com/codex/tasks/task_e_68d0d8913b40832e80fa61911aaacba6