### PR TITLE
Align v0.3.1 changelogs

### DIFF
--- a/Changelogs/GitHub/v0.3.1.md
+++ b/Changelogs/GitHub/v0.3.1.md
@@ -1,0 +1,6 @@
+# Release Notes v0.3.1
+## Highlights
+- BUGFIX: Alerted diners now follow the full escape flow so parties stay intact, orders clear safely, and lives drop only on real exits.
+- BUGFIX: Persistent corpses now rot and remain on appliances without breaking overnight cleanup.
+- BUGFIX: Poison automation skips invalid targets and keeps processing every occupant without stalling.
+- BUGFIX: Suspicion indicators only play valid audio and shut off when hidden to avoid missing clip errors.

--- a/Changelogs/Workshop/v0.3.1.bbcode
+++ b/Changelogs/Workshop/v0.3.1.bbcode
@@ -1,0 +1,9 @@
+[h1]Release Notes v0.3.1[/h1]
+
+[h2]Highlights[/h2]
+[list]
+[*]BUGFIX: Alerted diners now follow the full escape flow so parties stay intact, orders clear safely, and lives drop only on real exits.
+[*]BUGFIX: Persistent corpses now rot and remain on appliances without breaking overnight cleanup.
+[*]BUGFIX: Poison automation skips invalid targets and keeps processing every occupant without stalling.
+[*]BUGFIX: Suspicion indicators only play valid audio and shut off when hidden to avoid missing clip errors.
+[/list]


### PR DESCRIPTION
## Summary
- shorten the v0.3.1 GitHub highlights with BUGFIX prefixes and chronological ordering
- add a matching v0.3.1 Workshop changelog entry with the same BUGFIX highlights

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68d1c63cd96c832ea157934fd8f7701d