### PR TITLE
Require Fully Loaded update

### DIFF
--- a/Changelogs/GitHub/v0.3.1.md
+++ b/Changelogs/GitHub/v0.3.1.md
@@ -1,0 +1,7 @@
+# Release Notes v0.3.1
+## Highlights
+- FEATURE: Updated to PlateUp! Fully Loaded (v1.2.7 or later).
+- BUGFIX: Alerted diners now follow the full escape flow so parties stay intact, orders clear safely, and lives deduct when they actually exit.
+- BUGFIX: Persistent corpses now rot and remain on appliances without breaking overnight cleanup.
+- BUGFIX: Poison automation skips invalid targets and keeps processing every occupant without stalling.
+- BUGFIX: Suspicion indicators only play valid audio and shut off when hidden to avoid missing clip errors.

--- a/Changelogs/Workshop/v0.3.1.bbcode
+++ b/Changelogs/Workshop/v0.3.1.bbcode
@@ -1,0 +1,10 @@
+[h1]Release Notes v0.3.1[/h1]
+
+[h2]Highlights[/h2]
+[list]
+[*]FEATURE: Updated to PlateUp! Fully Loaded (v1.2.7 or later).
+[*]BUGFIX: Alerted diners now follow the full escape flow so parties stay intact, orders clear safely, and lives deduct when they actually exit.
+[*]BUGFIX: Persistent corpses now rot and remain on appliances without breaking overnight cleanup.
+[*]BUGFIX: Poison automation skips invalid targets and keeps processing every occupant without stalling.
+[*]BUGFIX: Suspicion indicators only play valid audio and shut off when hidden to avoid missing clip errors.
+[/list]

--- a/Mod.cs
+++ b/Mod.cs
@@ -24,10 +24,10 @@ namespace KitchenMysteryMeat
     {
         public const string MOD_GUID = "com.quackandcheese.mysterymeat";
         public const string MOD_NAME = "Mystery Meat";
-        public static new readonly Version ModVersion = new Version(0, 3, 0);
+        public static new readonly Version ModVersion = new Version(0, 3, 1);
         public static string ModVersionString => ModVersion.ToString();
         public const string MOD_AUTHOR = "QuackAndCheese";
-        public const string MOD_GAMEVERSION = ">=1.1.9";
+        public const string MOD_GAMEVERSION = ">=1.2.7";
 
         internal static AssetBundle Bundle;
         internal static KitchenLogger Logger;


### PR DESCRIPTION
## Summary
- raise the mod's required game version to >=1.2.7 so it targets the Fully Loaded update
- surface the Fully Loaded requirement as a FEATURE highlight at the top of the GitHub and Workshop v0.3.1 changelog entries

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d1c63cd96c832ea157934fd8f7701d