### PR TITLE
Centralize debug logging initialization and usage

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -90,6 +90,9 @@ namespace KitchenMysteryMeat
             Bundle = mod.GetPacks<AssetBundleModPack>().SelectMany(e => e.AssetBundles).FirstOrDefault() ?? throw new MissingAssetBundleException(MOD_GUID);
             Logger = InitLogger();
 
+            // Registers the mod logger with the debug helper immediately so future log calls reuse the shared reference.
+            DebugLogSystem.Initialize(Logger);
+
             // Configures the debug logging helper immediately after the logger is created.
             DebugLogSystem.Configure(Logger, () => ActiveDebugLogLevel);
 

--- a/Systems/ApplyIllegalSightEffects.cs
+++ b/Systems/ApplyIllegalSightEffects.cs
@@ -26,8 +26,8 @@ namespace KitchenMysteryMeat.Systems
 
             using (NativeArray<Entity> allEntities = query.ToEntityArray(Allocator.Temp))
             {
-                // Log the total number of illegal entities discovered for debugging purposes.
-                Mod.Logger?.LogInfo($"[ApplyIllegalSightEffects] Processing {allEntities.Length} illegal entities at day start.");
+                // Log the total number of illegal entities discovered for debugging purposes using the debug helper.
+                DebugLogSystem.LogInfo($"[ApplyIllegalSightEffects] Processing {allEntities.Length} illegal entities at day start.");
 
                 // Guard: short-circuit when no illegal entities require processing.
                 if (allEntities.Length > 0)
@@ -40,23 +40,23 @@ namespace KitchenMysteryMeat.Systems
                         Entity entity = allEntities[i];
 
                         // Emit a debug line for each entity as it is evaluated.
-                        Mod.Logger?.LogInfo($"[ApplyIllegalSightEffects] Evaluating entity {entity.Index}.");
+                        DebugLogSystem.LogVerbose($"[ApplyIllegalSightEffects] Evaluating entity {entity.Index}.");
 
                         // Handle illegal items by spawning rotten replacements.
                         if (ctx.Has<CItem>(entity))
                         {
-                            Mod.Logger?.LogInfo($"[ApplyIllegalSightEffects] Transforming illegal item entity {entity.Index}.");
+                            DebugLogSystem.LogVerbose($"[ApplyIllegalSightEffects] Transforming illegal item entity {entity.Index}.");
                             CorpseEffects.TransformCorpse(ctx, entity);
                         }
                         // Handle illegal appliances that swap to their configured replacements.
                         else if (ctx.Has<CAppliance>(entity))
                         {
-                            Mod.Logger?.LogInfo($"[ApplyIllegalSightEffects] Replacing illegal appliance entity {entity.Index}.");
+                            DebugLogSystem.LogVerbose($"[ApplyIllegalSightEffects] Replacing illegal appliance entity {entity.Index}.");
                             CorpseEffects.ReplaceWithAppliance(ctx, entity);
                         }
                         else
                         {
-                            Mod.Logger?.LogInfo($"[ApplyIllegalSightEffects] Entity {entity.Index} lacked item or appliance components.");
+                            DebugLogSystem.LogVerbose($"[ApplyIllegalSightEffects] Entity {entity.Index} lacked item or appliance components.");
                         }
                     }
                 }

--- a/Systems/Effects/Effect_TransformCorpse.cs
+++ b/Systems/Effects/Effect_TransformCorpse.cs
@@ -8,6 +8,7 @@ using KitchenLib.Utils;
 using KitchenMysteryMeat;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Items;
+using KitchenMysteryMeat.Systems;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems.Effects
@@ -208,10 +209,10 @@ namespace KitchenMysteryMeat.Systems.Effects
             return false;
         }
 
-        // Emits debug output through the mod logger when available.
+        // Emits debug output through the shared debug logging helper so verbosity remains configurable.
         private static void LogCorpseDebug(string message)
         {
-            Mod.Logger?.LogInfo(message);
+            DebugLogSystem.LogVerbose(message);
         }
     }
 }

--- a/Systems/Logging/DebugLogSystem.cs
+++ b/Systems/Logging/DebugLogSystem.cs
@@ -11,7 +11,23 @@ namespace KitchenMysteryMeat.Systems
     public static class DebugLogSystem
     {
         private static KitchenLogger _logger;
-        private static Func<DebugLogLevel> _levelProvider = () => DebugLogLevel.Off;
+        private static Func<DebugLogLevel> _levelProvider;
+
+        /// <summary>
+        /// Establishes the logger reference used by the debug log system.
+        /// Contributors should invoke this entry point from <see cref="Mod"/> during startup so
+        /// that all future logging is routed through the helper and benefits from centralised
+        /// formatting and level checks.
+        /// </summary>
+        /// <param name="logger">The logger instance supplied by the mod host.</param>
+        public static void Initialize(KitchenLogger logger)
+        {
+            // Stores the provided logger once to avoid reassigning a working reference mid-session.
+            if (_logger == null && logger != null)
+            {
+                _logger = logger;
+            }
+        }
 
         /// <summary>
         /// Configures the log system with the current logger instance and active debug level provider.
@@ -21,8 +37,13 @@ namespace KitchenMysteryMeat.Systems
         public static void Configure(KitchenLogger logger, Func<DebugLogLevel> levelProvider)
         {
             // Stores the logger and level provider so log calls can use the most recent configuration.
-            _logger = logger;
-            _levelProvider = levelProvider ?? (() => DebugLogLevel.Off);
+            Initialize(logger);
+
+            // Captures the supplied level provider so callers can override the default accessor.
+            if (levelProvider != null)
+            {
+                _levelProvider = levelProvider;
+            }
         }
 
         /// <summary>
@@ -135,8 +156,15 @@ namespace KitchenMysteryMeat.Systems
         /// <returns>The active debug logging level.</returns>
         private static DebugLogLevel GetConfiguredLevel()
         {
-            // Retrieves the debug level from the provider when available.
-            DebugLogLevel configuredLevel = _levelProvider != null ? _levelProvider.Invoke() : DebugLogLevel.Off;
+            // Begins with the mod accessor so early startup scenarios remain safe when preferences are unavailable.
+            DebugLogLevel configuredLevel = Mod.ActiveDebugLogLevel;
+
+            // Allows custom providers to override the accessor when explicitly configured.
+            if (_levelProvider != null)
+            {
+                configuredLevel = _levelProvider.Invoke();
+            }
+
             return configuredLevel;
         }
 


### PR DESCRIPTION
## Summary
- add a dedicated DebugLogSystem.Initialize entry point so the logger is registered once and document it for contributors
- ensure DebugLogSystem falls back to Mod.ActiveDebugLogLevel during startup and configure it from Mod.OnPostActivate
- route existing corpse and illegal sight systems through the helper so debug output observes preference levels

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1e99f127c832ea69b8f6867c156c1