### PR TITLE
Document and log automated poison interaction

### DIFF
--- a/Systems/CombinerPoisonInteraction.cs
+++ b/Systems/CombinerPoisonInteraction.cs
@@ -1,25 +1,27 @@
-﻿using Kitchen;
+using Kitchen;
 using KitchenData;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
-using UnityEngine.UI;
 
 namespace KitchenMysteryMeat.Systems
 {
     [UpdateAfter(typeof(AttemptInteraction))]
     [UpdateInGroup(typeof(InteractionGroup), OrderFirst = true)]
+    /// <summary>
+    /// Coordinates automated interactors that wield poison bottles so they apply poison to reachable occupants
+    /// positioned in front of them, mirroring the poisoning behaviour a player would perform manually.
+    /// </summary>
     public class CombinerPoisonInteraction : GenericSystemBase, IModSystem
     {
         private EntityQuery InteractivesQuery;
 
+        /// <summary>
+        /// Configures the entity query that gathers automated interactors equipped with the required spatial and holder data.
+        /// </summary>
         protected override void Initialise()
         {
             base.Initialise();
@@ -27,36 +29,53 @@ namespace KitchenMysteryMeat.Systems
                             .All(typeof(CAutomatedInteractor), typeof(CPosition), typeof(CItemHolder)));
         }
 
+        /// <summary>
+        /// Applies poison from automated interactors holding poison bottles to valid forward targets when the tile is reachable
+        /// and the occupant carries an unpoisoned item.
+        /// </summary>
         protected override void OnUpdate()
         {
-            using NativeArray<Entity> _automatedInteractors = InteractivesQuery.ToEntityArray(Allocator.Temp);
+            using NativeArray<Entity> automatedInteractors = InteractivesQuery.ToEntityArray(Allocator.Temp);
 
-            foreach (Entity automatedInteractor in _automatedInteractors)
+            // Iterate through each automated interactor to evaluate poisoning opportunities.
+            foreach (Entity automatedInteractor in automatedInteractors)
             {
+                DebugLogSystem.LogVerbose($"Processing automated interactor {automatedInteractor.Index} for poison evaluation.");
                 CPosition position = GetComponent<CPosition>(automatedInteractor);
                 CAutomatedInteractor auto = GetComponent<CAutomatedInteractor>(automatedInteractor);
                 CItemHolder itemHolder = GetComponent<CItemHolder>(automatedInteractor);
 
+                // Guard: skip when the interactor does not currently hold a poison bottle.
                 if (!Has<CPoisonBottle>(itemHolder.HeldItem))
                 {
                     continue;
                 }
 
-                CAutomatedInteractorRandomActiveInterval cautomatedInteractorRandomActiveInterval;
-                if (base.Require<CAutomatedInteractorRandomActiveInterval>(automatedInteractor, out cautomatedInteractorRandomActiveInterval) && !cautomatedInteractorRandomActiveInterval.Active)
+                // Guard: skip when the interactor is inactive because its random interval is disabled.
+                if (base.Require<CAutomatedInteractorRandomActiveInterval>(automatedInteractor, out CAutomatedInteractorRandomActiveInterval randomInterval) && !randomInterval.Active)
                 {
+                    DebugLogSystem.LogVerbose($"Skipping interactor {automatedInteractor.Index} because the random interval is inactive.");
                     continue;
                 }
+
                 Vector3 forwardPosition = position.ForwardPosition;
                 Entity occupant = TileManager.GetOccupant(forwardPosition, OccupancyLayer.Default);
+
+                // Guard: warn when the interactor cannot reach the tile in front of it.
                 if (!TileManager.CanReach(position, forwardPosition, false))
                 {
+                    DebugLogSystem.LogWarning($"Automated interactor {automatedInteractor.Index} cannot reach tile at {forwardPosition} while attempting to poison.");
                     continue;
                 }
-                if (occupant == default(Entity))
+
+                // Guard: warn when there is no occupant present to receive the interaction.
+                if (occupant == Entity.Null)
                 {
+                    DebugLogSystem.LogWarning($"Automated interactor {automatedInteractor.Index} found no occupant at {forwardPosition} when attempting to poison.");
                     continue;
                 }
+
+                // Request the interaction attempt so downstream systems perform the grab logic.
                 EntityManager.AddComponentData<CAttemptingInteraction>(automatedInteractor, new CAttemptingInteraction
                 {
                     Target = occupant,
@@ -66,12 +85,20 @@ namespace KitchenMysteryMeat.Systems
                     Mode = InteractionMode.Items,
                     TransferOnly = auto.TransferOnly
                 });
+
+                // Branch: attempt to poison only when the interactor is performing a grab interaction.
                 if (auto.Type == InteractionType.Grab)
                 {
-                    if (base.Require<CItemHolder>(occupant, out var occupantItem) && occupantItem.HeldItem != Entity.Null && !base.Has<CPoisoned>(occupantItem.HeldItem))
+                    // Guard: ensure the occupant holds an unpoisoned item before applying poison.
+                    if (base.Require<CItemHolder>(occupant, out CItemHolder occupantItem) && occupantItem.HeldItem != Entity.Null && !base.Has<CPoisoned>(occupantItem.HeldItem))
                     {
                         EntityManager.AddComponent<CPoisoned>(occupantItem.HeldItem);
                         CSoundEvent.Create(EntityManager, Mod.PoisonSoundEvent);
+                        DebugLogSystem.LogInfo($"Applied poison to entity {occupantItem.HeldItem.Index} using interactor {automatedInteractor.Index}.");
+                    }
+                    else
+                    {
+                        DebugLogSystem.LogVerbose($"Interactor {automatedInteractor.Index} found no valid item to poison on occupant {occupant.Index}.");
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- document the automated poison system and describe its update loop logic
- add guard comments and DebugLogSystem breadcrumbs, warnings, and success notices
- streamline imports and maintain verbose logging when no valid poisoning target exists

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d23c1e6898832e979390b249b72971