### PR TITLE
Improve customer component initialisation logging

### DIFF
--- a/Systems/AddComponentsToCustomers.cs
+++ b/Systems/AddComponentsToCustomers.cs
@@ -3,20 +3,25 @@ using KitchenData;
 using KitchenLib.Utils;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+using KitchenMysteryMeat.Systems.Logging;
 using System.Text;
-using System.Threading.Tasks;
 using Unity.Collections;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems
 {
+    /// <summary>
+    /// Equips customers with interaction and suspicion data so Mystery Meat gameplay systems can
+    /// drive bespoke behaviour and suspicion tracking.
+    /// </summary>
     public class AddComponentsToCustomers : GameSystemBase, IModSystem
     {
         private EntityQuery CustomersWithoutInteractive;
         private EntityQuery CustomersWithoutSuspicionIndicator;
+        /// <summary>
+        /// Builds queries that locate customers missing interactive or suspicion components for
+        /// later enrichment during updates.
+        /// </summary>
         protected override void Initialise()
         {
             CustomersWithoutInteractive = GetEntityQuery(new QueryHelper()
@@ -32,22 +37,81 @@ namespace KitchenMysteryMeat.Systems
                             ));
         }
 
+        /// <summary>
+        /// Adds the necessary interaction and suspicion components to customers while emitting
+        /// diagnostics about the affected entities.
+        /// </summary>
         protected override void OnUpdate()
         {
-            EntityManager.AddComponent<CIsInteractive>(CustomersWithoutInteractive);
+            // Gather customers that need the interactive component so they respond to manual inputs.
+            using NativeArray<Entity> customersNeedingInteractive = CustomersWithoutInteractive.ToEntityArray(Allocator.TempJob);
 
-            using NativeArray<Entity> _customersWithoutSuspicionIndicator = CustomersWithoutSuspicionIndicator.ToEntityArray(Allocator.TempJob);
-
-            float totalTime = HasStatus((RestaurantStatus)VariousUtils.GetID("cautiouscrowd")) ? 1.0f : 2.0f;
-
-            foreach (Entity customer in _customersWithoutSuspicionIndicator)
+            // Guard: log a warning when no customers were found even though the system expects pending arrivals.
+            if (customersNeedingInteractive.Length == 0)
             {
-                EntityManager.AddComponentData(customer, new CSuspicionIndicator()
+                DebugLogSystem.LogWarning("AddComponentsToCustomers found no customers requiring CIsInteractive despite expecting pending assignments.");
+            }
+            else
+            {
+                // Add the interactive component so customers can be targeted by custom interactions.
+                EntityManager.AddComponent<CIsInteractive>(CustomersWithoutInteractive);
+                DebugLogSystem.LogInfo($"Added CIsInteractive to {customersNeedingInteractive.Length} customers to enable interaction handling.");
+
+                // Emit verbose diagnostics enumerating the customers that received the interactive component.
+                StringBuilder interactiveCustomersBuilder = new StringBuilder();
+                for (int i = 0; i < customersNeedingInteractive.Length; i++)
                 {
-                    IndicatorType = Enums.SuspicionIndicatorType.Suspicious,
-                    TotalTime = totalTime,
-                    RemainingTime = totalTime,
-                });
+                    if (interactiveCustomersBuilder.Length > 0)
+                    {
+                        interactiveCustomersBuilder.Append(", ");
+                    }
+
+                    interactiveCustomersBuilder.Append(customersNeedingInteractive[i].Index);
+                }
+
+                DebugLogSystem.LogVerbose($"Interactive component applied to customers: {interactiveCustomersBuilder}");
+            }
+
+            // Collect customers lacking suspicion indicators so they can be tracked for suspicious actions.
+            using NativeArray<Entity> customersNeedingSuspicionIndicator = CustomersWithoutSuspicionIndicator.ToEntityArray(Allocator.TempJob);
+
+            // Detect the cautious crowd status to determine the appropriate suspicion timer duration.
+            bool hasCautiousCrowdStatus = HasStatus((RestaurantStatus)VariousUtils.GetID("cautiouscrowd"));
+
+            // Adjust suspicion timing so cautious crowd customers escalate faster than normal patrons.
+            float totalTime = hasCautiousCrowdStatus ? 1.0f : 2.0f;
+
+            // Guard: log a warning when no customers were found even though indicators are expected during service.
+            if (customersNeedingSuspicionIndicator.Length == 0)
+            {
+                DebugLogSystem.LogWarning("AddComponentsToCustomers found no customers requiring CSuspicionIndicator despite expecting customer tracking.");
+            }
+            else
+            {
+                // Emit verbose diagnostics enumerating the customers that received suspicion indicators.
+                StringBuilder suspicionCustomersBuilder = new StringBuilder();
+
+                // Apply suspicion indicator data to each affected customer so suspicion drains over the configured duration.
+                for (int i = 0; i < customersNeedingSuspicionIndicator.Length; i++)
+                {
+                    Entity customer = customersNeedingSuspicionIndicator[i];
+                    EntityManager.AddComponentData(customer, new CSuspicionIndicator()
+                    {
+                        IndicatorType = Enums.SuspicionIndicatorType.Suspicious,
+                        TotalTime = totalTime,
+                        RemainingTime = totalTime,
+                    });
+
+                    if (suspicionCustomersBuilder.Length > 0)
+                    {
+                        suspicionCustomersBuilder.Append(", ");
+                    }
+
+                    suspicionCustomersBuilder.Append(customer.Index);
+                }
+
+                DebugLogSystem.LogInfo($"Added CSuspicionIndicator to {customersNeedingSuspicionIndicator.Length} customers with a total time of {totalTime:0.##} seconds.");
+                DebugLogSystem.LogVerbose($"Suspicion indicator applied to customers: {suspicionCustomersBuilder}");
             }
         }
     }


### PR DESCRIPTION
## Summary
- document how AddComponentsToCustomers equips interaction and suspicion data during initialisation and updates
- log informational, verbose, and warning messages when applying interaction and suspicion components to customers
- explain the cautious crowd timing adjustments and enumerate the affected customers in verbose output

## Testing
- dotnet build *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d23c20c594832ebf05826db6d8eb39