### PR TITLE
Demote combiner empty tile log to verbose

### DIFF
--- a/Systems/CombinerPoisonInteraction.cs
+++ b/Systems/CombinerPoisonInteraction.cs
@@ -68,10 +68,10 @@ namespace KitchenMysteryMeat.Systems
                     continue;
                 }
 
-                // Guard: warn when there is no occupant present to receive the interaction.
+                // Guard: capture verbose breadcrumb when no occupant is available to interact with.
                 if (occupant == Entity.Null)
                 {
-                    DebugLogSystem.LogWarning($"Automated interactor {automatedInteractor.Index} found no occupant at {forwardPosition} when attempting to poison.");
+                    DebugLogSystem.LogVerbose($"Automated interactor {automatedInteractor.Index} found no occupant at {forwardPosition} when attempting to poison.");
                     continue;
                 }
 


### PR DESCRIPTION
## Summary
- demote the automated combiner empty-tile log to verbose to avoid routine warning spam
- clarify the inline comment to reflect the verbose breadcrumb purpose

## Testing
- attempted `dotnet build` (fails: command not found in container)


------
https://chatgpt.com/codex/tasks/task_e_68d249595690832e99f215fb90270a1c