### PR TITLE
Add top navigation tables to documentation

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -3,6 +3,17 @@
 
 # Feature Catalog
 
+## Navigation
+- [Gameplay Systems](#gameplay-systems)
+- [Items](#items)
+- [Appliances and Environmental Objects](#appliances-and-environmental-objects)
+- [Item Groups and Recipes](#item-groups-and-recipes)
+- [Dishes and Unlocks](#dishes-and-unlocks)
+- [Status Cards and Effects](#status-cards-and-effects)
+- [Visuals and Audio](#visuals-and-audio)
+- [Preferences and Tooling](#preferences-and-tooling)
+
+<a id="gameplay-systems"></a>
 ## Gameplay Systems [🔝](#top)
 - Murder loop that lets staff execute diners with the Meat Cleaver, spawn corpses, and splatter gore.
 - Suspicion meters that react to illegal sights, escalate to alerts, and end a day if an alerted diner escapes.
@@ -12,6 +23,7 @@
 - Process gore rules that let specific recipes spawn blood messes during work, including corpse carving.
 - Mince refinement that enables kneading raw mince into uncooked burger patties for the Mystery Meat menu.
 
+<a id="items"></a>
 ## Items [🔝](#top)
 - Meat Cleaver: equippable tool that murders customers and boosts chopping speed.
 - Mystery Meat: harvestable ingredient from corpses that supports chopping and grinding.
@@ -23,6 +35,7 @@
 - Empty Special Sauce Bottle: refillable shell supplied before the sauce is brewed.
 - Poison Bottle: reusable vessel that flags contaminated food as poisoned.
 
+<a id="appliances-and-environmental-objects"></a>
 ## Appliances and Environmental Objects [🔝](#top)
 - Manual Meat Grinder that accepts grindable items, plays preference-controlled audio, and outputs through a repositioned hold point.
 - Automatic Meat Grinder that runs the grind process unattended, conveys outputs, and emits grinder audio.
@@ -34,10 +47,12 @@
 - Rotten Customer Floor Corpse appliance that yields rotten corpses while staying suspicious.
 - Blood Spill messes (three stages) that slow players, require cleaning time, stack in place, and can be bottled for sauce.
 
+<a id="item-groups-and-recipes"></a>
 ## Item Groups and Recipes [🔝](#top)
 - Raw Hotdog assembly combining mince with a casing before cooking.
 - Uncooked Pie assembly pairing raw pie crust with mystery meat prior to baking.
 
+<a id="dishes-and-unlocks"></a>
 ## Dishes and Unlocks [🔝](#top)
 - Mystery Meat Burgers as the base restaurant dish, blocking standard meat providers and defining the fresh-meat workflow.
 - Mystery Meat Hotdogs as a main course unlocked after burgers, requiring casings and the grind process.
@@ -45,17 +60,20 @@
 - Special Sauce as an extra course that adds refillable condiment requests for plated mains.
 - Mystery Meat recipe entry that delivers the clandestine preparation instructions without being draftable.
 
+<a id="status-cards-and-effects"></a>
 ## Status Cards and Effects [🔝](#top)
 - Cautious Crowd status that shortens suspicion timers by half.
 - Messy Murder status that increases the number of blood spills spawned by a kill.
 - Persistent Corpses status that keeps corpses between days and lets them rot instead of despawning.
 
+<a id="visuals-and-audio"></a>
 ## Visuals and Audio [🔝](#top)
 - Suspicion indicator view that swaps between suspicion and alert icons, plays volume-controlled loops, and always faces the camera.
 - Meat grinder view that moves and scales the held item to illustrate grind progress.
 - Limited-use bottle view that swaps bottle and liquid materials to show remaining charges.
 - Dedicated stab, poison, and alert sound events registered with preference-driven volume control.
 
+<a id="preferences-and-tooling"></a>
 ## Preferences and Tooling [🔝](#top)
 - In-game preference sliders covering meat grinder, stab, suspicion, and alert audio levels.
 - Preference toggles that gate the Cautious Crowd, Messy Murder, and Persistent Corpses status cards.

--- a/QA_RUBRIC.md
+++ b/QA_RUBRIC.md
@@ -3,6 +3,16 @@
 
 # Mystery Meat QA Rubric
 
+## Navigation
+- [1. Mod Configuration and Preference Checks](#mod-configuration-and-preference-checks)
+- [2. Murder Loop and Gore Generation](#murder-loop-and-gore-generation)
+- [3. Suspicion, Alerts, and Loss Conditions](#suspicion-alerts-and-loss-conditions)
+- [4. Illegal Sight Persistence and Overnight Behaviour](#illegal-sight-persistence-and-overnight-behaviour)
+- [5. Special Sauce Lifecycle](#special-sauce-lifecycle)
+- [6. Poisoning Flow](#poisoning-flow)
+- [7. Meat Processing and Dish Coverage](#meat-processing-and-dish-coverage)
+
+<a id="mod-configuration-and-preference-checks"></a>
 ## 1. Mod Configuration and Preference Checks [🔝](#top)
 - **Test: Mystery Meat preference page exposes all controls.**
   - Steps:
@@ -36,6 +46,7 @@
     - No Mystery Meat debug chatter appears when set to Off.
     - Informational and verbose notes appear after elevating the preference.
 
+<a id="murder-loop-and-gore-generation"></a>
 ## 2. Murder Loop and Gore Generation [🔝](#top)
 - **Test: Meat Cleaver kills diners in every seating state.**
   - Steps:
@@ -64,6 +75,7 @@
     - Orders tied to dead members disappear.
     - The group indicator despawns after all members are dead or have left.
 
+<a id="suspicion-alerts-and-loss-conditions"></a>
 ## 3. Suspicion, Alerts, and Loss Conditions [🔝](#top)
 - **Test: Suspicion indicator attaches to every new diner.**
   - Steps:
@@ -94,6 +106,7 @@
   - Expected Results:
     - The run loses a life immediately upon exit and the diner despawns.
 
+<a id="illegal-sight-persistence-and-overnight-behaviour"></a>
 ## 4. Illegal Sight Persistence and Overnight Behaviour [🔝](#top)
 - **Test: Corpses rot without Persistent Corpses.**
   - Steps:
@@ -122,6 +135,7 @@
   - Expected Results:
     - The trash bag still contains the carcass next day, and the bag visuals reflect the filled state.
 
+<a id="special-sauce-lifecycle"></a>
 ## 5. Special Sauce Lifecycle [🔝](#top)
 - **Test: Empty bottles fill from fresh blood.**
   - Steps:
@@ -147,6 +161,7 @@
   - Expected Results:
     - The bottle converts to the empty version and can be refilled from blood puddles.
 
+<a id="poisoning-flow"></a>
 ## 6. Poisoning Flow [🔝](#top)
 - **Test: Manual poisoning contaminates held food.**
   - Steps:
@@ -169,6 +184,7 @@
   - Expected Results:
     - The second attempt does not replay the sound or alter the item further.
 
+<a id="meat-processing-and-dish-coverage"></a>
 ## 7. Meat Processing and Dish Coverage [🔝](#top)
 - **Test: Grindable items feed both grinders.**
   - Steps:


### PR DESCRIPTION
## Summary
- add quick navigation menus to the Feature Catalog and QA Rubric documents
- add stable anchors for each section so the new navigation links jump to the right spot

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3079cc5a4832e8d811e03b6a99238