### PR TITLE
Register runtime hooks after initialisation

### DIFF
--- a/Docs/PhaseNotes/Phase1_OnInitialise_Audit.md
+++ b/Docs/PhaseNotes/Phase1_OnInitialise_Audit.md
@@ -1,0 +1,49 @@
+# Phase 1 Audit – OnInitialise vs. OnPostActivate
+
+## Summary of Current Responsibilities
+| Action | Current Location | Classification | Dependencies / Order Constraints | Notes |
+| --- | --- | --- | --- | --- |
+| Emit ASCII art banner through `DebugLogSystem.LogInfo`. | `OnInitialise()` | Post-activation | Needs `DebugLogSystem.Initialise` to have captured a real `KitchenLogger`. | Executes before the logger is created, so the banner is currently dropped. Intended for celebratory post-activation output.
+| Resolve the primary asset bundle via `mod.GetPacks<AssetBundleModPack>()` (with fallback exception). | `OnPostActivate()` | Initialization | Requires a `Mod` context to enumerate packs; everything else that touches assets relies on this bundle. | First heavy-duty operation in `OnPostActivate`; failure aborts activation.
+| Acquire the KitchenLib logger through `InitLogger()`. | `OnPostActivate()` | Initialization | None, but `DebugLogSystem.Initialise` depends on the logger existing. | Sets `Mod.Logger` for reuse across helpers.
+| Wire up the debug helper with `DebugLogSystem.Initialise(Logger, () => ActiveDebugLogLevel)`. | `OnPostActivate()` | Initialization | Requires `Logger`; later reads of `ActiveDebugLogLevel` expect `PrefManager` to be initialised. | Currently runs before preferences, so the delegate returns `Off` until the manager is created.
+| Preload bundle textures via `Bundle.LoadAllAssets<Texture2D>()`. | `OnPostActivate()` | Initialization | Requires `Bundle`. | Helps avoid late asset lookups; safe to run as soon as the bundle is available.
+| Preload bundle sprites via `Bundle.LoadAllAssets<Sprite>()`. | `OnPostActivate()` | Initialization | Requires `Bundle`. | Same as textures; should accompany other bundle priming work.
+| Load custom `TMP_SpriteAsset` (`"GrindMeat"`). | `OnPostActivate()` | Initialization | Requires `Bundle`. | Acts as setup for TextMeshPro emoji support.
+| Append sprite asset to `TMP_Settings.defaultSpriteAsset.fallbackSpriteAssets`. | `OnPostActivate()` | Initialization | Requires sprite asset loaded and TextMeshPro settings to be accessible. | Ensures the game can resolve the meat grinder emoji.
+| Clone default TMP material and assign it to the custom sprite asset. | `OnPostActivate()` | Initialization | Requires sprite asset and `TMP_Settings.defaultSpriteAsset.material`. | Guarantees isolation from shared material mutations.
+| Load the sprite texture (`"GrindMeatTex"`) and assign it to the cloned material. | `OnPostActivate()` | Initialization | Requires `Bundle` and cloned material. | Finalises sprite rendering setup; tightly coupled with prior sprite steps.
+| Instantiate `PreferenceSystemManager`. | `OnPostActivate()` | Initialization | Requires mod identifiers; later preference access (`ActiveDebugLogLevel`) depends on this manager. | Foundation for all preference registrations.
+| Build helper arrays via `IntArrayGenerator` for 0–100% sliders. | `OnPostActivate()` | Initialization | Requires `IntArrayGenerator`. | Supplies the volume option lists; must precede menu option registration.
+| Define debug log level value/label arrays. | `OnPostActivate()` | Initialization | None beyond constant enum values. | Input to the debug preference option.
+| Configure the preference menu hierarchy (`AddLabel`, `AddOption`, `AddSubmenu`, etc.). | `OnPostActivate()` | Initialization | Requires `PrefManager` and generated arrays. | Populates audio, card, and debug settings with defaults.
+| Register the pause-menu preferences via `PrefManager.RegisterMenu(...)`. | `OnPostActivate()` | Initialization | Requires completed menu definition. | Makes the configuration accessible in-game; expected to occur before preferences are queried elsewhere.
+| Conditionally register `CautiousCrowdCard`. | `OnPostActivate()` | Post-activation | Requires `PrefManager` to fetch user choice; depends on KitchenLib systems being ready to accept new GDOs. | Directly tied to gameplay data, so it should remain in the activation phase.
+| Conditionally register `MessyMurderCard`. | `OnPostActivate()` | Post-activation | Same as above. | Same reasoning as the previous card.
+| Conditionally register `PersistentCorpsesCard`. | `OnPostActivate()` | Post-activation | Same as above. | Same reasoning as the previous card.
+| Subscribe to `Events.BuildGameDataEvent`. | `OnPostActivate()` | Post-activation | Requires KitchenLib events to be live; handler relies on `Bundle`. | Last-mile hook: waits for game data creation before mutating it.
+| Extend `ItemReferences.Mince` with a kneading-derived process inside the event handler. | `BuildGameDataEvent` handler (registered in `OnPostActivate`) | Post-activation | Handler executes when game data exists; requires `GDOUtils` lookups to succeed. | Modifies core item behaviour; must execute after the database is built.
+| Register stab SFX clips through `SetupSFX`. | `BuildGameDataEvent` handler | Post-activation | Needs `Bundle`, access to `gameData.ReferableObjects`, and event timing. | Ensures clip collection exists before audio IDs are used elsewhere.
+| Register poison SFX clip through `SetupSFX`. | `BuildGameDataEvent` handler | Post-activation | Same as above. | Maintains parity with other sound events.
+| Register alert SFX clip through `SetupSFX`. | `BuildGameDataEvent` handler | Post-activation | Same as above. | Completes audio registration set.
+
+## Logging and Debug Preference Observations
+- `OnInitialise()` calls `DebugLogSystem.LogInfo` before any logger has been initialised. Because `DebugLogSystem` resolves `Mod.Logger` lazily and `InitLogger()` does not run until `OnPostActivate()`, the ASCII banner is suppressed instead of appearing at startup. Moving banner emission to a point after `DebugLogSystem.Initialise` would allow the preference-aware logger to render it.
+- The debug helper honours three levels:
+  - **Off** (`0`): suppresses info, warning, and verbose logs; errors still emit without stack traces.
+  - **On** (`1`): allows info/warning output and attaches stack traces for diagnostic clarity.
+  - **Verbose** (`2`): keeps the previous behaviour and adds explicit verbose messages.
+- `DebugLogSystem.Initialise` captures a delegate to `ActiveDebugLogLevel`. Until `PrefManager` is constructed, that accessor returns `Off`, so early log calls from activation steps will default to the quietest level. Once preferences finish loading, subsequent evaluations will respect the stored selection.
+
+## Potential Risks When Rebalancing Responsibilities
+- **Asset bundle access in `OnInitialise`:** `OnPostActivate(Mod mod)` currently supplies the `mod` handle used to enumerate `AssetBundleModPack` instances. We need to confirm whether the base class exposes an equivalent accessor during `OnInitialise` or if the handle must be cached earlier to avoid regressions.
+- **Preference availability for early debug level reads:** If `PrefManager` is moved forward, we must ensure the preference backing store can be initialised prior to activation without triggering duplicate registrations or missing menu attachments.
+- **TextMeshPro asset manipulation timing:** Relocating sprite asset configuration to `OnInitialise` should be validated against Unity’s loading lifecycle to ensure `TMP_Settings.defaultSpriteAsset` is ready and does not require the game data context present during activation.
+- **Audio registration dependencies:** `SetupSFX` relies on both the asset bundle and the runtime `GameData` container. Only the bundle work should shift earlier; the actual `GameData` mutation must remain tied to a post-activation event where the referable registries exist.
+- **Card registration ordering:** `AddGameDataObject<T>` calls may depend on KitchenLib’s activation pipeline. Moving them too early could bypass necessary initialization steps or execute before preferences set their defaults.
+
+## Clarifications Needed for Phase 2
+- What is the recommended way to access asset bundles during `OnInitialise` when the `mod` parameter is unavailable? Should we cache the `Mod` instance earlier or use a KitchenLib helper?
+- Does KitchenLib guarantee that preference registration in `OnInitialise` will still surface menus in the pause screen, or must menu registration occur after activation?
+- Are there side effects if `AddGameDataObject` is invoked before `OnPostActivate`, or is activation the earliest safe hook for new game data objects?
+- Should the celebratory banner respect the debug level (only display when `DebugLogLevel` ≥ `On`), or is it expected to show regardless of verbosity settings?

--- a/Docs/PhaseNotes/Phase2_Prompt.md
+++ b/Docs/PhaseNotes/Phase2_Prompt.md
@@ -1,0 +1,39 @@
+**Context**
+
+Repository: `/workspace/MysteryMeat`
+Primary file: `Mod.cs`
+
+Goals:
+- Move all heavy initialisation (logger, asset bundle, preferences) into `OnInitialise`.
+- Restrict `OnPostActivate` to finalisation tasks (banner emission, runtime hooks) that assume initialisation completed.
+- Ensure debug logging honours the Off/On/Verbose preference, including stack traces for On and Verbose levels via `DebugLogSystem`.
+- Maintain Microsoft .NET conventions and keep comments JavaDoc-like, focusing on purpose and order of operations.
+
+Community guidance (collated from Reddit and Discord PlateUp modding threads):
+- `OnInitialise` is safe for synchronous resource loading and preference setup.
+- `OnPostActivate` should only handle activation success messaging and runtime hooks.
+- Event subscriptions depending on game data should verify assets and preferences are ready before wiring handlers.
+
+**Tasks**
+1. Refactor lifecycle methods
+   - Ensure `OnInitialise` prepares the logger, debug helper, asset bundle, and preferences without relying on activation.
+   - Update `OnPostActivate` to call `EnsureInitialisation(mod)` and skip runtime hooks if initialisation fails, logging a high-priority error when that occurs.
+   - Emit the ASCII banner only after activation and only when the logger is ready.
+
+2. Consolidate conditional logic
+   - Replace the repeated card registration `if` statements with a collection-driven loop (e.g., tuples containing preference IDs and registration delegates).
+   - Apply similar consolidation to other repetitive guards while respecting readability and avoiding excessive returns.
+
+3. Strengthen runtime guards
+   - Subscribe to `Events.BuildGameDataEvent` only when the asset bundle and preferences are initialised.
+   - Gate `SetupSFX` operations behind bundle and game-data availability checks, logging warnings or errors when dependencies are missing.
+   - Consider extracting helper methods to clarify readiness checks before performing runtime registrations.
+
+4. Documentation & comments
+   - Add summary comments to each method and purpose-driven comments before non-trivial logic blocks (especially guards).
+   - Update or create documentation under `Docs/PhaseNotes` describing audit findings and current responsibilities so future phases have historical context.
+
+5. Testing & reporting
+   - Run available validation commands (e.g., `dotnet build`) and record outcomes for the project manager.
+
+Deliverables: Clean commit with refactored code, updated comments, and refreshed documentation. Ensure `git status` is clean before handoff.

--- a/Mod.cs
+++ b/Mod.cs
@@ -2,6 +2,7 @@ using System;
 using KitchenLib;
 using KitchenLib.Logging.Exceptions;
 using KitchenMods;
+using System.Collections;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -34,6 +35,12 @@ namespace KitchenMysteryMeat
 
         internal static AssetBundle Bundle;
         internal static KitchenLogger Logger;
+
+        private static KitchenMods.Mod _modContext;
+        private static bool _assetsInitialised;
+        private static bool _preferencesInitialised;
+        private static bool _buildGameDataEventSubscribed;
+        private static bool _runtimeHooksRegistered;
 
         /// <summary>
         /// Gets the ASCII art banner displayed when the mod is initialised.
@@ -105,12 +112,30 @@ namespace KitchenMysteryMeat
         }
 
         /// <summary>
-        /// Handles initial mod setup and displays the load notification banner.
+        /// Handles initial mod setup, including logger configuration, asset acquisition, and preference preparation.
         /// </summary>
         protected override void OnInitialise()
         {
-            // Emit a startup info post through the debug helper so it respects the configured verbosity.
-            DebugLogSystem.LogInfo(ModLoadedBanner);
+            // Ensure the logger exists before any other system attempts to emit diagnostic output.
+            Logger = InitLogger();
+
+            // Initialise the debug helper immediately so all subsequent log calls share the same configuration.
+            DebugLogSystem.Initialise(Logger, () => ActiveDebugLogLevel);
+            DebugLogSystem.LogVerbose("Logger initialised during OnInitialise.");
+
+            // Attempt to resolve the mod context prior to loading assets so the bundle is available early.
+            bool initialisedDuringLoad = EnsureInitialisation(null);
+
+            // Guard: communicate when dependencies are unavailable so activation can complete the workflow later.
+            if (!initialisedDuringLoad)
+            {
+                DebugLogSystem.LogWarning("Initialisation deferred until activation because the asset bundle or preferences were not fully ready during OnInitialise.");
+            }
+            else
+            {
+                CompleteRuntimeRegistration();
+                DebugLogSystem.LogVerbose("Initialisation completed successfully during OnInitialise.");
+            }
         }
 
         /// <summary>
@@ -121,198 +146,488 @@ namespace KitchenMysteryMeat
         }
 
         /// <summary>
-        /// Handles asset loading and preference initialisation after the mod is activated.
+        /// Handles final activation tasks such as completing any deferred setup, registering game data, and emitting the banner.
         /// </summary>
         protected override void OnPostActivate(KitchenMods.Mod mod)
         {
-            Bundle = mod.GetPacks<AssetBundleModPack>().SelectMany(e => e.AssetBundles).FirstOrDefault() ?? throw new MissingAssetBundleException(MOD_GUID);
-            Logger = InitLogger();
+            // Ensure the initialisation routine completes even if portions were deferred during OnInitialise.
+            bool initialised = EnsureInitialisation(mod);
 
-            // Initialise the debug helper immediately so all subsequent log calls share the same configuration.
-            DebugLogSystem.Initialise(Logger, () => ActiveDebugLogLevel);
-
-            Bundle.LoadAllAssets<Texture2D>();
-            Bundle.LoadAllAssets<Sprite>();
-            var spriteAsset = Bundle.LoadAsset<TMP_SpriteAsset>("GrindMeat");
-            TMP_Settings.defaultSpriteAsset.fallbackSpriteAssets.Add(spriteAsset);
-            spriteAsset.material = UnityEngine.Object.Instantiate(TMP_Settings.defaultSpriteAsset.material);
-            spriteAsset.material.mainTexture = Bundle.LoadAsset<Texture2D>("GrindMeatTex");
-
-            #region Preferences
-            PrefManager = new PreferenceSystemManager(MOD_GUID, MOD_NAME);
-
-            IntArrayGenerator intArrayGenerator = new IntArrayGenerator();
-            intArrayGenerator.AddRange(0, 100, 10, null, delegate (string prefKey, int value)
+            // Guard: skip runtime registrations when initialisation failed to protect against null bundles or preferences.
+            if (!initialised)
             {
-                return $"{value}%";
-            });
-            int[] zeroToHundredPercentValues = intArrayGenerator.GetArray();
-            string[] zeroToHundredPercentStrings = intArrayGenerator.GetStrings();
-            int[] debugLogLevelValues = new[]
-            {
-                (int)DebugLogLevel.Off,
-                (int)DebugLogLevel.On,
-                (int)DebugLogLevel.Verbose
-            };
-            string[] debugLogLevelLabels = new[]
-            {
-                "Off",
-                "On",
-                "Verbose"
-            };
-            intArrayGenerator.Clear();
-
-            PrefManager
-                .AddLabel("Mystery Meat")
-                .AddSpacer()
-                .AddSubmenu("Audio Settings", "AudioSubmenu")
-                    .AddLabel("Audio Settings")
-                    .AddSpacer()
-                    .AddLabel("Meat Grinder Volume")
-                    .AddOption<int>(
-                        MEAT_GRINDER_VOLUME_ID,
-                        50,
-                        zeroToHundredPercentValues,
-                        zeroToHundredPercentStrings)
-                    .AddLabel("Stab Volume")
-                    .AddOption<int>(
-                        STAB_VOLUME_ID,
-                        50,
-                        zeroToHundredPercentValues,
-                        zeroToHundredPercentStrings)
-                    .AddLabel("Suspicion Volume")
-                    .AddOption<int>(
-                        SUSPICION_VOLUME_ID,
-                        50,
-                        zeroToHundredPercentValues,
-                        zeroToHundredPercentStrings)
-                    .AddLabel("Alert Volume")
-                    .AddOption<int>(
-                        ALERT_VOLUME_ID,
-                        50,
-                        zeroToHundredPercentValues,
-                        zeroToHundredPercentStrings)
-                    .AddSpacer()
-                    .AddSpacer()
-                    .SubmenuDone()
-                .AddSubmenu("Card Settings", "CardSubmenu")
-                    .AddLabel("Card Settings")
-                    .AddInfo("Any changes require a restart.")
-                    .AddLabel("Cautious Crowd")
-                    .AddOption<bool>(
-                        CAUTIOUS_CROWD_ENABLED_ID,
-                        true,
-                        [true, false],
-                        ["Enabled", "Disabled"]
-                    )
-                    .AddLabel("Messy Murder")
-                    .AddOption<bool>(
-                        MESSY_MURDER_ENABLED_ID,
-                        true,
-                        [true, false],
-                        ["Enabled", "Disabled"]
-                    )
-                    .AddLabel("Persistent Corpses")
-                    .AddOption<bool>(
-                        PERSISTENT_CORPSES_ENABLED_ID,
-                        true,
-                        [true, false],
-                        ["Enabled", "Disabled"]
-                    )
-                    .AddSpacer()
-                    .AddSpacer()
-                    .SubmenuDone()
-                // Adds debug settings for controlling log output verbosity.
-                .AddSubmenu("Debug Settings", "DebugSubmenu")
-                    .AddLabel("Debug Settings")
-                    .AddOption<int>(
-                        DEBUG_LOG_LEVEL_ID,
-                        (int)DebugLogLevel.Off,
-                        debugLogLevelValues,
-                        debugLogLevelLabels)
-                    .AddSpacer()
-                    .AddSpacer()
-                    .SubmenuDone()
-            .AddSpacer()
-            .AddSpacer();
-
-            PrefManager.RegisterMenu(PreferenceSystemManager.MenuType.PauseMenu);
-            #endregion
-
-            if (Mod.PrefManager.Get<bool>(CAUTIOUS_CROWD_ENABLED_ID))
-            {
-                AddGameDataObject<CautiousCrowdCard>();
+                DebugLogSystem.LogError("Mystery Meat activation aborted because required assets or preferences were unavailable during OnPostActivate.");
             }
-            if (Mod.PrefManager.Get<bool>(MESSY_MURDER_ENABLED_ID))
+            else
             {
-                AddGameDataObject<MessyMurderCard>();
+                CompleteRuntimeRegistration();
+                DebugLogSystem.LogInfo(ModLoadedBanner);
+                DebugLogSystem.LogVerbose("Mystery Meat activation completed.");
             }
-            if (Mod.PrefManager.Get<bool>(PERSISTENT_CORPSES_ENABLED_ID))
-            {
-                AddGameDataObject<PersistentCorpsesCard>();
-            }
-
-
-            Events.BuildGameDataEvent += delegate (object s, BuildGameDataEventArgs args)
-            {
-                //((Item)GDOUtils.GetExistingGDO(ItemReferences.SharpKnife)).Properties.Add(new CKillsCustomer());
-                ((Item)GDOUtils.GetExistingGDO(ItemReferences.Mince)).DerivedProcesses.Add(new Item.ItemProcess()
-                {
-                    Process = (Process)GDOUtils.GetExistingGDO(ProcessReferences.Knead),
-                    Result = (Item)GDOUtils.GetExistingGDO(ItemReferences.BurgerPattyRaw),
-                    Duration = 0.75f
-                });
-
-                SetupSFX(args.gamedata);
-            };
         }
-        
+
+        /// <summary>
+        /// Finalises runtime hooks once assets and preferences are available.
+        /// </summary>
+        private void CompleteRuntimeRegistration()
+        {
+            bool prerequisitesReady = _assetsInitialised && _preferencesInitialised && Bundle != null && PrefManager != null;
+
+            // Guard: ensure assets and preferences exist before wiring runtime hooks.
+            if (!prerequisitesReady)
+            {
+                DebugLogSystem.LogError("Mystery Meat runtime registration skipped because assets or preferences were unavailable.");
+            }
+            else if (_runtimeHooksRegistered)
+            {
+                DebugLogSystem.LogVerbose("Mystery Meat runtime registration was already completed; skipping duplicate work.");
+            }
+            else
+            {
+                RegisterConfiguredCards();
+                SubscribeToBuildGameDataEvent();
+                _runtimeHooksRegistered = true;
+                DebugLogSystem.LogVerbose("Mystery Meat runtime hooks registered successfully.");
+            }
+        }
+
+        /// <summary>
+        /// Registers gameplay cards based on the active preference configuration.
+        /// </summary>
+        private void RegisterConfiguredCards()
+        {
+            // Guard: ensure the preference manager is available before interrogating configuration values.
+            if (PrefManager == null)
+            {
+                DebugLogSystem.LogError("Mystery Meat preferences were unavailable during activation; gameplay cards were not registered to avoid inconsistent state.");
+            }
+            else
+            {
+                // Collects the card registration actions alongside their controlling preference identifiers.
+                var cardRegistrations = new (string PreferenceId, Action Register, string CardName)[]
+                {
+                    (CAUTIOUS_CROWD_ENABLED_ID, () => AddGameDataObject<CautiousCrowdCard>(), nameof(CautiousCrowdCard)),
+                    (MESSY_MURDER_ENABLED_ID, () => AddGameDataObject<MessyMurderCard>(), nameof(MessyMurderCard)),
+                    (PERSISTENT_CORPSES_ENABLED_ID, () => AddGameDataObject<PersistentCorpsesCard>(), nameof(PersistentCorpsesCard))
+                };
+
+                foreach (var card in cardRegistrations)
+                {
+                    // Guard: evaluate the stored preference before registering the associated game data object.
+                    bool isEnabled = PrefManager.Get<bool>(card.PreferenceId);
+
+                    if (isEnabled)
+                    {
+                        card.Register();
+                        DebugLogSystem.LogVerbose($"Registered {card.CardName} because its preference is enabled.");
+                    }
+                    else
+                    {
+                        DebugLogSystem.LogVerbose($"Skipped registration for {card.CardName} because its preference is disabled.");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Subscribes to the build game data event when assets and preferences are ready for runtime hooks.
+        /// </summary>
+        private void SubscribeToBuildGameDataEvent()
+        {
+            // Guard: prevent duplicate subscriptions when activation occurs more than once.
+            if (_buildGameDataEventSubscribed)
+            {
+                DebugLogSystem.LogVerbose("Mystery Meat BuildGameDataEvent subscription was already active; skipping duplicate registration.");
+            }
+            else
+            {
+                // Determines whether runtime prerequisites have been satisfied before subscribing.
+                bool runtimeReady = _assetsInitialised && _preferencesInitialised && Bundle != null && PrefManager != null;
+
+                // Guard: ensure the runtime dependencies exist before wiring the build game data event.
+                if (!runtimeReady)
+                {
+                    DebugLogSystem.LogError("Mystery Meat skipped BuildGameDataEvent subscription because assets or preferences were not initialised.");
+                }
+                else
+                {
+                    Events.BuildGameDataEvent += OnBuildGameData;
+                    _buildGameDataEventSubscribed = true;
+                    DebugLogSystem.LogVerbose("Mystery Meat subscribed to BuildGameDataEvent.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Handles the BuildGameData event by extending mince behaviour and registering custom audio clips.
+        /// </summary>
+        /// <param name="sender">The event source.</param>
+        /// <param name="args">The event data containing the game database.</param>
+        private void OnBuildGameData(object sender, BuildGameDataEventArgs args)
+        {
+            // Guard: verify that the event supplied valid game data before applying modifications.
+            bool hasGameData = args?.gamedata != null;
+
+            if (!hasGameData)
+            {
+                DebugLogSystem.LogWarning("Mystery Meat received BuildGameDataEvent without valid game data; mince extensions and SFX registration were skipped.");
+            }
+            else if (Bundle == null)
+            {
+                DebugLogSystem.LogError("Mystery Meat BuildGameDataEvent handler skipped because the asset bundle was unavailable.");
+            }
+            else
+            {
+                // Extends mince with a kneading process to produce burger patties as soon as game data is available.
+                Item mince = (Item)GDOUtils.GetExistingGDO(ItemReferences.Mince);
+                Process knead = (Process)GDOUtils.GetExistingGDO(ProcessReferences.Knead);
+                Item patty = (Item)GDOUtils.GetExistingGDO(ItemReferences.BurgerPattyRaw);
+
+                bool hasProcess = mince.DerivedProcesses.Any(p => p.Process == knead && p.Result == patty);
+
+                // Guard: avoid duplicating the derived process when the handler executes more than once.
+                if (!hasProcess)
+                {
+                    mince.DerivedProcesses.Add(new Item.ItemProcess()
+                    {
+                        Process = knead,
+                        Result = patty,
+                        Duration = 0.75f
+                    });
+                    DebugLogSystem.LogVerbose("Mystery Meat added knead-to-patty process to mince during BuildGameDataEvent.");
+                }
+
+                // Ensures the custom stab, poison, and alert audio clips are registered for runtime use.
+                SetupSFX(args.gamedata);
+            }
+        }
+
         /// <summary>
         /// Loads the stab, poison, and alert audio assets into the game's referable clip registry.
         /// </summary>
         /// <param name="gameData">The game data collection that receives the mod-specific sound effects.</param>
         private void SetupSFX(GameData gameData)
         {
-            #region Stab
-            StabSoundEvent = (SoundEvent)VariousUtils.GetID(MOD_GUID + "-STAB");
+            bool dependenciesReady = gameData != null && Bundle != null;
 
-            if (!gameData.ReferableObjects.Clips.ContainsKey(StabSoundEvent))
-                gameData.ReferableObjects.Clips.Add(StabSoundEvent, new AudioAssetRandom());
+            // Guard: ensure dependencies are ready before touching game data or bundle assets.
+            if (!dependenciesReady)
+            {
+                // Guard: surface helpful diagnostics when the event did not provide game data.
+                if (gameData == null)
+                {
+                    DebugLogSystem.LogWarning("Mystery Meat skipped SFX registration because BuildGameDataEvent supplied null game data.");
+                }
 
-            var stab1 = Bundle.LoadAsset<AudioClip>("stab-01"); stab1.LoadAudioData();
-            var stab2 = Bundle.LoadAsset<AudioClip>("stab-02"); stab2.LoadAudioData();
-            var stab3 = Bundle.LoadAsset<AudioClip>("stab-03"); stab3.LoadAudioData();
+                // Guard: emit an error when the bundle is missing because no audio clips can be registered.
+                if (Bundle == null)
+                {
+                    DebugLogSystem.LogError("Mystery Meat skipped SFX registration because the asset bundle was unavailable.");
+                }
+            }
+            else
+            {
+                #region Stab
+                StabSoundEvent = (SoundEvent)VariousUtils.GetID(MOD_GUID + "-STAB");
 
-            typeof(AudioAssetRandom)
-                .GetField("Clips", BindingFlags.Instance | BindingFlags.NonPublic)
-                .SetValue(gameData.ReferableObjects.Clips[StabSoundEvent], new List<AudioClip>() { stab1, stab2, stab3 });
-            #endregion
+                // Guard: register the stab sound container when the clip registry does not yet know the event.
+                if (!gameData.ReferableObjects.Clips.ContainsKey(StabSoundEvent))
+                {
+                    gameData.ReferableObjects.Clips.Add(StabSoundEvent, new AudioAssetRandom());
+                }
 
-            #region Poison
-            PoisonSoundEvent = (SoundEvent)VariousUtils.GetID(MOD_GUID + "-POISON");
+                var stab1 = Bundle.LoadAsset<AudioClip>("stab-01");
+                stab1.LoadAudioData();
+                var stab2 = Bundle.LoadAsset<AudioClip>("stab-02");
+                stab2.LoadAudioData();
+                var stab3 = Bundle.LoadAsset<AudioClip>("stab-03");
+                stab3.LoadAudioData();
 
-            if (!gameData.ReferableObjects.Clips.ContainsKey(PoisonSoundEvent))
-                gameData.ReferableObjects.Clips.Add(PoisonSoundEvent, new AudioAsset());
+                typeof(AudioAssetRandom)
+                    .GetField("Clips", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .SetValue(gameData.ReferableObjects.Clips[StabSoundEvent], new List<AudioClip>() { stab1, stab2, stab3 });
+                #endregion
 
-            var poison1 = Bundle.LoadAsset<AudioClip>("blub"); poison1.LoadAudioData();
+                #region Poison
+                PoisonSoundEvent = (SoundEvent)VariousUtils.GetID(MOD_GUID + "-POISON");
 
-            typeof(AudioAsset)
-                .GetField("Clip", BindingFlags.Instance | BindingFlags.NonPublic)
-                .SetValue(gameData.ReferableObjects.Clips[PoisonSoundEvent], poison1);
-            #endregion
+                // Guard: register the poison sound container when the clip registry does not yet know the event.
+                if (!gameData.ReferableObjects.Clips.ContainsKey(PoisonSoundEvent))
+                {
+                    gameData.ReferableObjects.Clips.Add(PoisonSoundEvent, new AudioAsset());
+                }
 
-            #region Alert
-            AlertSoundEvent = (SoundEvent)VariousUtils.GetID(MOD_GUID + "-ALERT");
+                var poison1 = Bundle.LoadAsset<AudioClip>("blub");
+                poison1.LoadAudioData();
 
-            if (!gameData.ReferableObjects.Clips.ContainsKey(AlertSoundEvent))
-                gameData.ReferableObjects.Clips.Add(AlertSoundEvent, new AudioAsset());
+                typeof(AudioAsset)
+                    .GetField("Clip", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .SetValue(gameData.ReferableObjects.Clips[PoisonSoundEvent], poison1);
+                #endregion
 
-            var alert1 = Bundle.LoadAsset<AudioClip>("alert"); alert1.LoadAudioData();
+                #region Alert
+                AlertSoundEvent = (SoundEvent)VariousUtils.GetID(MOD_GUID + "-ALERT");
 
-            typeof(AudioAsset)
-                .GetField("Clip", BindingFlags.Instance | BindingFlags.NonPublic)
-                .SetValue(gameData.ReferableObjects.Clips[AlertSoundEvent], alert1);
-            #endregion
+                // Guard: register the alert sound container when the clip registry does not yet know the event.
+                if (!gameData.ReferableObjects.Clips.ContainsKey(AlertSoundEvent))
+                {
+                    gameData.ReferableObjects.Clips.Add(AlertSoundEvent, new AudioAsset());
+                }
+
+                var alert1 = Bundle.LoadAsset<AudioClip>("alert");
+                alert1.LoadAudioData();
+
+                typeof(AudioAsset)
+                    .GetField("Clip", BindingFlags.Instance | BindingFlags.NonPublic)
+                    .SetValue(gameData.ReferableObjects.Clips[AlertSoundEvent], alert1);
+                #endregion
+            }
+        }
+
+        /// <summary>
+        /// Ensures that assets and preferences are initialised, optionally using the provided mod reference.
+        /// </summary>
+        /// <param name="mod">The mod context supplied during activation, or null when invoked during OnInitialise.</param>
+        /// <returns>True when all initialisation requirements have been satisfied.</returns>
+        private bool EnsureInitialisation(KitchenMods.Mod mod)
+        {
+            KitchenMods.Mod resolvedMod = ResolveModContext(mod);
+
+            InitialiseAssets(resolvedMod);
+            InitialisePreferences();
+
+            bool initialised = _assetsInitialised && _preferencesInitialised;
+            return initialised;
+        }
+
+        /// <summary>
+        /// Resolves the KitchenMods mod context either from activation or via the preloaded mod registry.
+        /// </summary>
+        /// <param name="mod">An optional mod reference obtained during activation.</param>
+        /// <returns>The resolved mod context, or null when unavailable.</returns>
+        private static KitchenMods.Mod ResolveModContext(KitchenMods.Mod mod)
+        {
+            KitchenMods.Mod resolvedContext = _modContext;
+
+            // Guard: prefer the provided mod reference because it is authoritative during activation.
+            if (mod != null)
+            {
+                _modContext = mod;
+                resolvedContext = _modContext;
+            }
+            else if (resolvedContext == null)
+            {
+                try
+                {
+                    FieldInfo modsField = typeof(ModPreload).GetField("Mods", BindingFlags.Public | BindingFlags.Static);
+
+                    // Guard: ensure the ModPreload dictionary is available before iterating over entries.
+                    if (modsField?.GetValue(null) is IDictionary modsDictionary)
+                    {
+                        foreach (DictionaryEntry entry in modsDictionary)
+                        {
+                            // Guard: only capture entries that expose a KitchenMods.Mod instance for the Mystery Meat identifier.
+                            if (entry.Value is KitchenMods.Mod candidate && string.Equals(candidate.ID, MOD_GUID, StringComparison.OrdinalIgnoreCase))
+                            {
+                                _modContext = candidate;
+                                DebugLogSystem.LogVerbose("Resolved Mystery Meat mod context from ModPreload.");
+                                break;
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    DebugLogSystem.LogError($"Failed to resolve the Mystery Meat mod context: {ex.Message}");
+                }
+
+                resolvedContext = _modContext;
+            }
+
+            return resolvedContext;
+        }
+
+        /// <summary>
+        /// Loads the Mystery Meat asset bundle and prepares TextMesh Pro resources when possible.
+        /// </summary>
+        /// <param name="mod">The mod reference providing access to the asset bundle packs.</param>
+        private static void InitialiseAssets(KitchenMods.Mod mod)
+        {
+            bool loadSuccessful = Bundle != null;
+
+            // Guard: only attempt to load assets when they have not been initialised yet.
+            if (!loadSuccessful)
+            {
+                // Guard: defer loading when the mod context is unavailable during initialisation.
+                if (mod == null)
+                {
+                    DebugLogSystem.LogWarning("Asset bundle loading deferred because the mod context was unavailable during initialisation.");
+                }
+                else
+                {
+                    try
+                    {
+                        Bundle = mod.GetPacks<AssetBundleModPack>().SelectMany(e => e.AssetBundles).FirstOrDefault() ?? throw new MissingAssetBundleException(MOD_GUID);
+
+                        Bundle.LoadAllAssets<Texture2D>();
+                        Bundle.LoadAllAssets<Sprite>();
+
+                        TMP_SpriteAsset spriteAsset = Bundle.LoadAsset<TMP_SpriteAsset>("GrindMeat");
+
+                        if (spriteAsset == null)
+                        {
+                            // Guard: ensure the sprite asset was located before configuring fallback settings.
+                            DebugLogSystem.LogError("Failed to locate the GrindMeat sprite asset within the Mystery Meat bundle.");
+                        }
+                        else
+                        {
+                            TMP_Settings.defaultSpriteAsset.fallbackSpriteAssets.Add(spriteAsset);
+                            spriteAsset.material = UnityEngine.Object.Instantiate(TMP_Settings.defaultSpriteAsset.material);
+
+                            Texture2D spriteTexture = Bundle.LoadAsset<Texture2D>("GrindMeatTex");
+
+                            // Guard: confirm the grind meat texture exists before applying it to the cloned material.
+                            if (spriteTexture == null)
+                            {
+                                DebugLogSystem.LogError("Failed to locate the GrindMeat texture within the Mystery Meat bundle.");
+                            }
+                            else
+                            {
+                                spriteAsset.material.mainTexture = spriteTexture;
+                                loadSuccessful = true;
+                                DebugLogSystem.LogVerbose("Mystery Meat asset bundle initialised successfully.");
+                            }
+                        }
+                    }
+                    catch (MissingAssetBundleException)
+                    {
+                        DebugLogSystem.LogError("Mystery Meat asset bundle missing; the mod cannot continue without the required assets.");
+                        throw;
+                    }
+                    catch (Exception ex)
+                    {
+                        DebugLogSystem.LogError($"Unexpected error while initialising the Mystery Meat assets: {ex.Message}");
+                        throw;
+                    }
+                }
+            }
+
+            _assetsInitialised = loadSuccessful;
+        }
+
+        /// <summary>
+        /// Builds the Mystery Meat preference menus, including audio, card, and debugging options.
+        /// </summary>
+        private static void InitialisePreferences()
+        {
+            bool preferencesReady = PrefManager != null;
+
+            // Guard: build the preference hierarchy only once to avoid duplicate registration.
+            if (!preferencesReady)
+            {
+                PrefManager = new PreferenceSystemManager(MOD_GUID, MOD_NAME);
+
+                IntArrayGenerator intArrayGenerator = new IntArrayGenerator();
+                intArrayGenerator.AddRange(0, 100, 10, null, delegate (string prefKey, int value)
+                {
+                    return $"{value}%";
+                });
+                int[] zeroToHundredPercentValues = intArrayGenerator.GetArray();
+                string[] zeroToHundredPercentStrings = intArrayGenerator.GetStrings();
+                int[] debugLogLevelValues = new[]
+                {
+                    (int)DebugLogLevel.Off,
+                    (int)DebugLogLevel.On,
+                    (int)DebugLogLevel.Verbose
+                };
+                string[] debugLogLevelLabels = new[]
+                {
+                    "Off",
+                    "On",
+                    "Verbose"
+                };
+                intArrayGenerator.Clear();
+
+                PrefManager
+                    .AddLabel("Mystery Meat")
+                    .AddSpacer()
+                    .AddSubmenu("Audio Settings", "AudioSubmenu")
+                        .AddLabel("Audio Settings")
+                        .AddSpacer()
+                        .AddLabel("Meat Grinder Volume")
+                        .AddOption<int>(
+                            MEAT_GRINDER_VOLUME_ID,
+                            50,
+                            zeroToHundredPercentValues,
+                            zeroToHundredPercentStrings)
+                        .AddLabel("Stab Volume")
+                        .AddOption<int>(
+                            STAB_VOLUME_ID,
+                            50,
+                            zeroToHundredPercentValues,
+                            zeroToHundredPercentStrings)
+                        .AddLabel("Suspicion Volume")
+                        .AddOption<int>(
+                            SUSPICION_VOLUME_ID,
+                            50,
+                            zeroToHundredPercentValues,
+                            zeroToHundredPercentStrings)
+                        .AddLabel("Alert Volume")
+                        .AddOption<int>(
+                            ALERT_VOLUME_ID,
+                            50,
+                            zeroToHundredPercentValues,
+                            zeroToHundredPercentStrings)
+                        .AddSpacer()
+                        .AddSpacer()
+                        .SubmenuDone()
+                    .AddSubmenu("Card Settings", "CardSubmenu")
+                        .AddLabel("Card Settings")
+                        .AddInfo("Any changes require a restart.")
+                        .AddLabel("Cautious Crowd")
+                        .AddOption<bool>(
+                            CAUTIOUS_CROWD_ENABLED_ID,
+                            true,
+                            [true, false],
+                            ["Enabled", "Disabled"]
+                        )
+                        .AddLabel("Messy Murder")
+                        .AddOption<bool>(
+                            MESSY_MURDER_ENABLED_ID,
+                            true,
+                            [true, false],
+                            ["Enabled", "Disabled"]
+                        )
+                        .AddLabel("Persistent Corpses")
+                        .AddOption<bool>(
+                            PERSISTENT_CORPSES_ENABLED_ID,
+                            true,
+                            [true, false],
+                            ["Enabled", "Disabled"]
+                        )
+                        .AddSpacer()
+                        .AddSpacer()
+                        .SubmenuDone()
+                    // Adds debug settings for controlling log output verbosity.
+                    .AddSubmenu("Debug Settings", "DebugSubmenu")
+                        .AddLabel("Debug Settings")
+                        .AddOption<int>(
+                            DEBUG_LOG_LEVEL_ID,
+                            (int)DebugLogLevel.Off,
+                            debugLogLevelValues,
+                            debugLogLevelLabels)
+                        .AddSpacer()
+                        .AddSpacer()
+                        .SubmenuDone()
+                .AddSpacer()
+                .AddSpacer();
+
+                PrefManager.RegisterMenu(PreferenceSystemManager.MenuType.PauseMenu);
+                DebugLogSystem.LogVerbose("Mystery Meat preferences initialised successfully.");
+                preferencesReady = true;
+            }
+
+            _preferencesInitialised = preferencesReady;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a runtime registration helper so card toggles and BuildGameData hooks are wired immediately after assets and preferences are ready
- ensure OnInitialise finalises runtime hooks when possible and have OnPostActivate only emit the banner after successful initialisation

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d2fec3b674832ea33af22901cde3ea