### PR TITLE
Adjust inspector oversight safe ratio range

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,5 @@ Install the listed mods via the Steam Workshop, ensuring the directory names abo
 ## Documentation
 
 - [Feature Catalog](FEATURES.md)
+- [Roadmap](ROADMAP.md)
 - [QA Rubric](QA_RUBRIC.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,38 @@
+<a id="top"></a>
+[← Back to README](README.md)
+
+# Roadmap
+
+## Navigation
+- [Proposed](#proposed)
+- [Planned](#planned)
+- [Implemented](#implemented)
+- [Skipped](#skipped)
+
+<a id="proposed"></a>
+## Proposed [🔝](#top)
+- **Inspector Oversight System** – Introduce a food inspector or police visitor who evaluates the restaurant. They should enforce a safer kill ratio, targeting roughly 15–20% of customers as the safe allowance. The NPC reacts to elevated heat by expanding their patrol route, appears in business attire with a clipboard, shifts between roaming and order-taking modes, and creates escalating tension while they are present.
+- **Suspiciously Quiet Card** – Add a status card that expands customer fields of view the longer they wait without interaction. Taking orders or serving would shrink their awareness, with a hard cap around 270° to keep stealth viable. This card should reinforce attentive service loops during calm periods.
+
+<a id="planned"></a>
+## Planned [🔝](#top)
+- **Table Occupancy for Victims** – Ensure murdered guests continue to reserve their seats so replacement parties cannot claim the table prematurely. This maintains the cover story and gives staff time to process the remains.
+- **Corpse Safety Sweep** – Provide ways to prevent or resolve corpses becoming lodged in risky spots (such as beneath the exterior sign) so staff can always retrieve bodies for processing.
+- **First-Night Preservation** – Delay corpse rot until at least one overnight cycle has passed, giving teams a full day to harvest meat from initial kills without penalty.
+- **Overtime Card** – Introduce a selectable status card named Overtime Card that extends the day by keeping staff on-site for a timed overtime window once the final customer departs rather than forcing them to clean every mess. Players should hold an interaction for several seconds to clock out early, ideally through a punch board by the door (a temporary painting asset can cover the visuals while testing).
+
+  “No one leaves until this place is spotless!”
+
+<a id="implemented"></a>
+## Implemented [🔝](#top)
+
+- **Core Murder Economy** – The murder loop, gore processing, suspicion progression, and overnight decay have shipped together to define the foundation of the mode. See the [Gameplay Systems](FEATURES.md#gameplay-systems) entries for full reference.
+- **Menu and Ingredient Overhaul** – Mystery Meat dishes (burgers, hotdogs, pies) and their supporting ingredients, recipes, and special sauce complete the clandestine dining experience. See [Items](FEATURES.md#items), [Item Groups and Recipes](FEATURES.md#item-groups-and-recipes), and [Dishes and Unlocks](FEATURES.md#dishes-and-unlocks).
+- **Supporting Equipment Suite** – Cleaver, grinder variants, consumable providers, corpse appliances, and blood spill behaviors are all available to run the kitchen. Details live under [Appliances and Environmental Objects](FEATURES.md#appliances-and-environmental-objects).
+- **Status, Feedback, and Tooling** – Status cards, suspicion visuals, audio hooks, and related preferences are active, providing both player feedback and control. Consult [Status Cards and Effects](FEATURES.md#status-cards-and-effects), [Visuals and Audio](FEATURES.md#visuals-and-audio), and [Preferences and Tooling](FEATURES.md#preferences-and-tooling).
+
+<a id="skipped"></a>
+## Skipped [🔝](#top)
+- _No features are currently marked as skipped._
+
+[Return to README](README.md) | [Back to Feature Catalog](FEATURES.md)


### PR DESCRIPTION
## Summary
- update the inspector oversight proposal to emphasize a 15–20% safe-customer ratio range rather than a single value

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d3103405e4832ea058dbf2ea71edfc