### PR TITLE
Fix runtime readiness guard and disambiguate debug logging

### DIFF
--- a/Mod.cs
+++ b/Mod.cs
@@ -204,31 +204,37 @@ namespace KitchenMysteryMeat
             // Ensure core services exist so activation can proceed with a configured logger and preferences.
             bool coreReady = EnsureCoreInitialisation();
 
+            // Attempt to resolve the Mystery Meat asset bundle for runtime usage.
+            bool assetsReady = EnsureAssetBundle(mod);
+
+            // Evaluate runtime readiness once dependencies have been initialised.
+            bool runtimeReady = IsRuntimeReady();
+
             // Guard: abort runtime registrations when the initialisation failed to acquire assets or preferences.
-            if (!isReady)
+            if (!runtimeReady)
             {
                 DebugLogSystem.LogError("Mystery Meat initialisation failed; runtime hooks and event subscriptions have been skipped to avoid null reference issues.");
-            }
-            else
-            {
-                // Emit a startup info post through the debug helper so it respects the configured verbosity.
-                DebugLogSystem.LogInfo(MysteryMeatBanner);
 
-            // Attempt to register runtime hooks now that activation has supplied every dependency.
-            TryRegisterRuntimeHooks();
-
-            // Guard: surface readiness gaps so players understand why activation did not emit the banner immediately.
-            if (!IsRuntimeReady())
-            {
+                // Guard: surface readiness gaps so players understand why activation did not emit the banner immediately.
                 if (!coreReady)
                 {
                     DebugLogSystem.LogError("Mystery Meat activation completed without initialising its core systems; review earlier logs for details.");
                 }
 
+                // Guard: highlight when the activation context failed to expose the expected asset bundle.
                 if (!assetsReady && mod != null)
                 {
                     DebugLogSystem.LogError("Mystery Meat activation completed without resolving its asset bundle; review earlier logs for details.");
                 }
+            }
+            else
+            {
+                // Emit a startup info post through the debug helper so it respects the configured verbosity.
+                DebugLogSystem.LogInfo(MysteryMeatBanner);
+                _bannerLogged = true;
+
+                // Attempt to register runtime hooks now that activation has supplied every dependency.
+                TryRegisterRuntimeHooks();
             }
         }
 

--- a/Mod.cs
+++ b/Mod.cs
@@ -191,7 +191,13 @@ namespace KitchenMysteryMeat
             // Guard: retry runtime hook registration and banner emission only while pending actions remain.
             if (!_cardsRegistered || !_buildGameDataSubscribed || !_bannerLogged)
             {
-                TryRegisterRuntimeHooks();
+                // Attempt to register runtime hooks now that activation has supplied every dependency.
+                if (TryRegisterRuntimeHooks())
+                {
+                    // Emit a startup info post through the debug helper so it respects the configured verbosity.
+                    DebugLogSystem.LogInfo(MysteryMeatBanner);
+                    _bannerLogged = true;
+                }
             }
         }
 
@@ -229,12 +235,13 @@ namespace KitchenMysteryMeat
             }
             else
             {
-                // Emit a startup info post through the debug helper so it respects the configured verbosity.
-                DebugLogSystem.LogInfo(MysteryMeatBanner);
-                _bannerLogged = true;
-
                 // Attempt to register runtime hooks now that activation has supplied every dependency.
-                TryRegisterRuntimeHooks();
+                if (TryRegisterRuntimeHooks())
+                {
+                    // Emit a startup info post through the debug helper so it respects the configured verbosity.
+                    DebugLogSystem.LogInfo(MysteryMeatBanner);
+                    _bannerLogged = true;
+                }
             }
         }
 
@@ -575,7 +582,7 @@ namespace KitchenMysteryMeat
         /// <summary>
         /// Attempts to register runtime hooks such as cards and game data subscriptions when dependencies are ready.
         /// </summary>
-        private void TryRegisterRuntimeHooks()
+        private bool TryRegisterRuntimeHooks()
         {
             // Guard: retry core initialisation when preferences are unavailable so transient failures can recover.
             if (PrefManager == null)
@@ -588,7 +595,7 @@ namespace KitchenMysteryMeat
             // Guard: defer registration until both assets and preferences are available.
             if (!runtimeReady)
             {
-                return;
+                return false;
             }
 
             // Guard: register cards only once per activation to avoid duplicate game data objects.
@@ -603,6 +610,8 @@ namespace KitchenMysteryMeat
 
             // Emit the banner once runtime readiness has been observed.
             AnnounceRuntimeReadinessIfNeeded();
+
+            return true;
         }
 
         /// <summary>

--- a/Systems/Logging/DebugLogSystem.cs
+++ b/Systems/Logging/DebugLogSystem.cs
@@ -1,8 +1,7 @@
 using System;
-using System.Diagnostics;
 using KitchenLib.Logging;
 using KitchenMysteryMeat.Enums;
-using UnityEngine;
+using UnityDebug = UnityEngine.Debug;
 
 namespace KitchenMysteryMeat.Systems.Logging
 {
@@ -56,7 +55,7 @@ namespace KitchenMysteryMeat.Systems.Logging
             else if (activeLevel >= DebugLogLevel.On)
             {
                 // Guard: fall back to Unity diagnostics when the Kitchen logger is unavailable.
-                Debug.Log(FormatMessage(message, includeStackTrace));
+                UnityDebug.Log(FormatMessage(message, includeStackTrace));
             }
         }
 
@@ -80,7 +79,7 @@ namespace KitchenMysteryMeat.Systems.Logging
             else if (activeLevel >= DebugLogLevel.On)
             {
                 // Guard: fall back to Unity diagnostics when the Kitchen logger is unavailable.
-                Debug.LogWarning(FormatMessage(message, includeStackTrace));
+                UnityDebug.LogWarning(FormatMessage(message, includeStackTrace));
             }
         }
 
@@ -104,7 +103,7 @@ namespace KitchenMysteryMeat.Systems.Logging
             else
             {
                 // Guard: fall back to Unity diagnostics when the Kitchen logger is unavailable.
-                Debug.LogError(FormatMessage(message, includeStackTrace));
+                UnityDebug.LogError(FormatMessage(message, includeStackTrace));
             }
         }
 
@@ -132,7 +131,7 @@ namespace KitchenMysteryMeat.Systems.Logging
                 else
                 {
                     // Guard: fall back to Unity diagnostics when the Kitchen logger is unavailable.
-                    Debug.Log(formattedMessage);
+                    UnityDebug.Log(formattedMessage);
                 }
             }
         }
@@ -186,7 +185,7 @@ namespace KitchenMysteryMeat.Systems.Logging
             if (includeStackTrace)
             {
                 // Generate a stack trace that skips the logging helper frames for clarity.
-                string stackTrace = new StackTrace(2, true).ToString();
+                string stackTrace = new System.Diagnostics.StackTrace(2, true).ToString();
 
                 // Append the stack trace only when the generated output contains meaningful content.
                 if (!string.IsNullOrWhiteSpace(stackTrace))


### PR DESCRIPTION
## Summary
- ensure OnPostActivate revalidates core services and asset bundles before registering runtime hooks
- log readiness gaps when activation cannot secure the expected dependencies and mark the banner as emitted when successful
- resolve the Unity Debug ambiguity by routing through an explicit alias and qualifying stack trace generation

## Testing
- dotnet build MysteryMeat.csproj *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d34c2cdcec832eb64f65f7b214aca7