### PR TITLE
Fix Debug reference ambiguity in logging system

### DIFF
--- a/Systems/Logging/DebugLogSystem.cs
+++ b/Systems/Logging/DebugLogSystem.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Diagnostics;
 using KitchenLib.Logging;
 using KitchenMysteryMeat.Enums;
 using UnityEngine;
@@ -186,7 +185,7 @@ namespace KitchenMysteryMeat.Systems.Logging
             if (includeStackTrace)
             {
                 // Generate a stack trace that skips the logging helper frames for clarity.
-                string stackTrace = new StackTrace(2, true).ToString();
+                string stackTrace = new System.Diagnostics.StackTrace(2, true).ToString();
 
                 // Append the stack trace only when the generated output contains meaningful content.
                 if (!string.IsNullOrWhiteSpace(stackTrace))


### PR DESCRIPTION
## Summary
- remove the System.Diagnostics using from the logging helper to avoid conflicting Debug symbols
- fully qualify the stack trace creation so UnityEngine.Debug remains the active fallback implementation

## Testing
- not run (dotnet CLI not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68d390c858c0832ead7b46b440d476df