### PR TITLE
Refine debug messaging and documentation

### DIFF
--- a/Customs/Appliances/AutomaticMeatGrinder.cs
+++ b/Customs/Appliances/AutomaticMeatGrinder.cs
@@ -6,6 +6,7 @@ using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Processes;
 using KitchenMysteryMeat.Views;
+using KitchenMysteryMeat.Systems.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -76,6 +77,9 @@ namespace KitchenMysteryMeat.Customs.Appliances
         static FieldInfo typeContainer = typeof(ConveyItemsView).GetField("TypeContainer", BindingFlags.NonPublic | BindingFlags.Instance);
         static FieldInfo animator = typeof(ConveyItemsView).GetField("Animator", BindingFlags.NonPublic | BindingFlags.Instance);*/
 
+        /// <summary>
+        /// Configures automation visuals and audio when the automatic grinder is registered.
+        /// </summary>
         public override void OnRegister(Appliance gameDataObject)
         {
             base.OnRegister(gameDataObject);
@@ -92,6 +96,7 @@ namespace KitchenMysteryMeat.Customs.Appliances
 
 
             MeatGrinderView meatGrinderView = gameDataObject.Prefab.AddComponent<MeatGrinderView>();
+            DebugLogSystem.LogVerbose("Configured automated components during registration.");
         }
     }
 }

--- a/Customs/Appliances/ManualMeatGrinder.cs
+++ b/Customs/Appliances/ManualMeatGrinder.cs
@@ -7,6 +7,7 @@ using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Processes;
 using KitchenMysteryMeat.MonoBehaviours;
 using KitchenMysteryMeat.Views;
+using KitchenMysteryMeat.Systems.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -72,6 +73,9 @@ namespace KitchenMysteryMeat.Customs.Appliances
         static FieldInfo typeContainer = typeof(ConveyItemsView).GetField("TypeContainer", BindingFlags.NonPublic | BindingFlags.Instance);
         static FieldInfo animator = typeof(ConveyItemsView).GetField("Animator", BindingFlags.NonPublic | BindingFlags.Instance);*/
 
+        /// <summary>
+        /// Configures hold points, audio, and view components when the manual grinder is registered.
+        /// </summary>
         public override void OnRegister(Appliance gameDataObject)
         {
             base.OnRegister(gameDataObject);
@@ -94,6 +98,7 @@ namespace KitchenMysteryMeat.Customs.Appliances
 
 
             MeatGrinderView meatGrinderView = gameDataObject.Prefab.AddComponent<MeatGrinderView>();
+            DebugLogSystem.LogVerbose("Configured hold point, audio, and view components during registration.");
         }
     }
 }

--- a/Customs/Appliances/MeatCleaverProvider.cs
+++ b/Customs/Appliances/MeatCleaverProvider.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using UnityEngine;
 using KitchenLib.References;
 using KitchenMysteryMeat.Customs.Items;
+using KitchenMysteryMeat.Systems.Logging;
 
 namespace KitchenMysteryMeat.Customs.Appliances
 {
@@ -42,9 +43,13 @@ namespace KitchenMysteryMeat.Customs.Appliances
             KitchenPropertiesUtils.GetCItemProvider(GDOUtils.GetCustomGameDataObject<MeatCleaver>().ID, 1, 1, false, false, false, false, false, false, false)
         };
 
+        /// <summary>
+        /// Configures the thin counter to provide meat cleavers to players.
+        /// </summary>
         public override void OnRegister(Appliance gameDataObject)
         {
             Helper.SetupThinCounterLimitedItem(Prefab, Mod.Bundle.LoadAsset<GameObject>("Meat Cleaver").AssignMaterialsByNames().AssignVFXByNames(), false);
+            DebugLogSystem.LogVerbose("Initialised limited item setup during registration.");
         }
     }
 }

--- a/Customs/Appliances/PoisonProvider.cs
+++ b/Customs/Appliances/PoisonProvider.cs
@@ -4,6 +4,7 @@ using KitchenLib.Customs;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Items;
+using KitchenMysteryMeat.Systems.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -44,9 +45,13 @@ namespace KitchenMysteryMeat.Customs.Appliances
             KitchenPropertiesUtils.GetCItemProvider(GDOUtils.GetCustomGameDataObject<PoisonBottle>().ID, 1, 1, false, false, true, false, false, true, false),
         };
 
+        /// <summary>
+        /// Configures the countertop to dispense poison bottles for gameplay interactions.
+        /// </summary>
         public override void OnRegister(Appliance gameDataObject)
         {
             Helper.SetupCounterLimitedItem(Prefab, Mod.Bundle.LoadAsset<GameObject>("Poison Bottle").AssignMaterialsByNames().AssignVFXByNames());
+            DebugLogSystem.LogVerbose("Initialised limited item setup during registration.");
         }
     }
 }

--- a/Customs/Appliances/SpecialSauceProvider.cs
+++ b/Customs/Appliances/SpecialSauceProvider.cs
@@ -4,6 +4,7 @@ using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Customs.Items;
+using KitchenMysteryMeat.Systems.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -55,9 +56,13 @@ namespace KitchenMysteryMeat.Customs.Appliances
             KitchenPropertiesUtils.GetCItemProvider(GDOUtils.GetCustomGameDataObject<EmptySpecialSauceBottle>().ID, 1, 1, false, false, true, false, false, true, false),
         };
 
+        /// <summary>
+        /// Configures the countertop prefab to dispense special sauce bottles.
+        /// </summary>
         public override void OnRegister(Appliance gameDataObject)
         {
             Helper.SetupCounterLimitedItem(Prefab, Mod.Bundle.LoadAsset<GameObject>("Empty Special Sauce Bottle").AssignMaterialsByNames().AssignVFXByNames());
+            DebugLogSystem.LogVerbose("Initialised limited item setup during registration.");
         }
     }
 }

--- a/Customs/Dishes/MysteryMeatDish.cs
+++ b/Customs/Dishes/MysteryMeatDish.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using UnityEngine;
+using KitchenMysteryMeat.Systems.Logging;
 
 namespace KitchenMysteryMeat.Customs.Dishes
 {
@@ -30,9 +31,13 @@ namespace KitchenMysteryMeat.Customs.Dishes
             (Locale.English, LocalisationUtils.CreateUnlockInfo("Mystery Meat", "Redrum", "How'd you get here?"))
         };
 
+        /// <summary>
+        /// Hides the info panel for the hidden base dish when registered.
+        /// </summary>
         public override void OnRegister(Dish gdo)
         {
             gdo.HideInfoPanel = true;
+            DebugLogSystem.LogVerbose("Registration hid the info panel for the hidden dish.");
         }
     }
 }

--- a/Customs/ItemGroups/UncookedPie.cs
+++ b/Customs/ItemGroups/UncookedPie.cs
@@ -5,6 +5,7 @@ using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Customs.Items;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.ItemGroups
@@ -48,15 +49,21 @@ namespace KitchenMysteryMeat.Customs.ItemGroups
             }
         };
 
-
+        /// <summary>
+        /// Configures the item group view to toggle components for the uncooked pie assembly.
+        /// </summary>
         public override void OnRegister(ItemGroup gameDataObject)
         {
             Prefab.GetComponent<UncookedPieItemGroupView>()?.Setup(Prefab);
+            DebugLogSystem.LogVerbose("Registered item group view setup for the uncooked pie.");
         }
     }
 
     public class UncookedPieItemGroupView : ItemGroupView
     {
+        /// <summary>
+        /// Configures component groups so the pie renders correct ingredients.
+        /// </summary>
         internal void Setup(GameObject prefab)
         {
             // This tells which sub-object of the prefab corresponds to each component of the ItemGroup

--- a/Customs/Items/CustomerCorpse.cs
+++ b/Customs/Items/CustomerCorpse.cs
@@ -5,6 +5,7 @@ using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Appliances;
+using KitchenMysteryMeat.Systems.Logging;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -12,6 +13,9 @@ namespace KitchenMysteryMeat.Customs.Items
 {
     public class CustomerCorpseItemView : ObjectsSplittableView
     {
+        /// <summary>
+        /// Configures corpse stage objects for the splittable view rendering.
+        /// </summary>
         internal void Setup(GameObject prefab)
         {
             var fObjects = ReflectionUtils.GetField<ObjectsSplittableView>("Objects");
@@ -58,12 +62,16 @@ namespace KitchenMysteryMeat.Customs.Items
             },
         };
 
+        /// <summary>
+        /// Ensures the corpse prefab includes the splittable view used for portion rendering.
+        /// </summary>
         public override void OnRegister(Item item)
         {
             if (!Prefab.HasComponent<CustomerCorpseItemView>())
             {
                 var view = Prefab.AddComponent<CustomerCorpseItemView>();
                 view.Setup(Prefab);
+                DebugLogSystem.LogVerbose("Attached CustomerCorpseItemView during registration.");
             }
         }
     }

--- a/Customs/Items/RottenCustomerCorpse.cs
+++ b/Customs/Items/RottenCustomerCorpse.cs
@@ -4,6 +4,7 @@ using KitchenLib.Customs;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Appliances;
+using KitchenMysteryMeat.Systems.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -45,12 +46,16 @@ namespace KitchenMysteryMeat.Customs.Items
             new CPreservedOvernight()
         };
 
+        /// <summary>
+        /// Ensures the rotten corpse prefab exposes the corpse view component when registered.
+        /// </summary>
         public override void OnRegister(Item item)
         {
             if (!Prefab.HasComponent<CustomerCorpseItemView>())
             {
                 var view = Prefab.AddComponent<CustomerCorpseItemView>();
                 view.Setup(Prefab);
+                DebugLogSystem.LogVerbose("Attached CustomerCorpseItemView during registration.");
             }
         }
     }

--- a/Customs/Items/SpecialSauceBottle.cs
+++ b/Customs/Items/SpecialSauceBottle.cs
@@ -5,6 +5,7 @@ using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Appliances;
 using KitchenMysteryMeat.Views;
+using KitchenMysteryMeat.Systems.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -32,6 +33,9 @@ namespace KitchenMysteryMeat.Customs.Items
             }
         };
 
+        /// <summary>
+        /// Attaches the limited-use bottle view to render sauce fill amounts.
+        /// </summary>
         public override void OnRegister(Item gameDataObject)
         {
             base.OnRegister(gameDataObject);
@@ -39,6 +43,7 @@ namespace KitchenMysteryMeat.Customs.Items
             LimitedUseBottleView limitedUseBottleView = Prefab.AddComponent<LimitedUseBottleView>();
             limitedUseBottleView.BottleMaterial = MaterialUtils.GetExistingMaterial("Tomato Flesh 3");
             limitedUseBottleView.LiquidMaterial = MaterialUtils.GetExistingMaterial("Clothing Red");
+            DebugLogSystem.LogVerbose("Attached LimitedUseBottleView during registration.");
         }
     }
 }

--- a/Customs/Items/TrashBag.cs
+++ b/Customs/Items/TrashBag.cs
@@ -6,6 +6,7 @@ using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Appliances;
 using KitchenMysteryMeat.Views;
+using KitchenMysteryMeat.Systems.Logging;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -35,11 +36,15 @@ namespace KitchenMysteryMeat.Customs.Items
                 Capacity = 1
             },
         };
+        /// <summary>
+        /// Attaches the trash bag view when the item is registered.
+        /// </summary>
         public override void OnRegister(Item gameDataObject)
         {
             base.OnRegister(gameDataObject);
 
             TrashBagView view = Prefab.AddComponent<TrashBagView>();
+            DebugLogSystem.LogVerbose("Attached trash bag view component during registration.");
         }
     }
 }

--- a/Docs/CommentDebugBacklog.md
+++ b/Docs/CommentDebugBacklog.md
@@ -1,0 +1,61 @@
+# Comment and Debug Coverage Backlog (Sept 24, 2025 @ 3:30 a.m. CST)
+
+This checklist captures every Mystery Meat code file that still lacks the required summary comments and/or integration with the updated debug logging system. Use it as the authoritative backlog for finishing the current documentation and diagnostics push.
+
+## Components
+- `Components/CEmptyBottle.cs` — Struct has no summary describing the empty bottle marker or how `FullBottleID` routes refills.
+- `Components/CFillsBottle.cs` — Missing summary on the appliance-side filler component and its `BottleID` contract.
+- `Components/CGrindable.cs` — Lacks a summary clarifying that it tags meat that should feed grinder processes.
+- `Components/CIllegalSight.cs` — Needs a summary covering illegal sight tracking and `TurnIntoOnDayStart` behavior.
+- `Components/CIllegalSightHolderPreserved.cs` — No summary documenting why the holder flag is preserved overnight.
+- `Components/CKilled.cs` — Missing explanation of the `Bloody` marker applied to dispatched customers.
+- `Components/CKillsCustomer.cs` — Needs summary describing how it marks tools that can kill customers.
+- `Components/CLimitedUseBottle.cs` — Requires documentation of the remaining charges state for limited bottles.
+- `Components/CMeatGrinder.cs` — Needs a summary that outlines grinder process IDs and input/output offsets.
+- `Components/CPersistPortions.cs` — Lacks a summary for the overnight portion preservation toggle.
+- `Components/CPoisonBottle.cs` — Missing summary on the poison bottle tag for exchange logic.
+- `Components/CPoisoned.cs` — Needs documentation summarizing the poison status marker.
+- `Components/CProcessCausesSpill.cs` — Summary required for spill metadata (process, mess ID, rate, overwrite flag).
+- `Components/CSuspicionIndicator.cs` — Missing summary on suspicion UI state tracking.
+- `Components/CTrashBag.cs` — Needs summary covering trash bag capacity and state fields.
+- `Components/CTurnIntoItem.cs` — Requires summary describing the conversion target logic.
+
+## Customs / Appliances
+- `Customs/Appliances/BloodSpill1.cs` — Class lacks high-level summary for the mess prefab and no verbose logging around bottle refill enabling.
+- `Customs/Appliances/BloodSpill2.cs` — Needs class-level summary and optional debug traces for stack progression behavior.
+- `Customs/Appliances/BloodSpill3.cs` — Missing summary for the final blood spill tier and associated cleanup timings.
+- `Customs/Appliances/CasingsProvider.cs` — No summary explaining the unlimited casings source or shop requirements.
+- `Customs/Appliances/CustomerFloorCorpse.cs` — Needs summary documenting corpse provider behavior and illegal sight handling.
+- `Customs/Appliances/RottenCustomerFloorCorpse.cs` — Missing summary for rotten corpse provider variant.
+- `Customs/Appliances/TrashBagProvider.cs` — Requires summary of trash bag vending logic and prerequisites.
+
+## Customs / Items
+- `Customs/Items/Casing.cs` — Lacks summary for casing item purpose and provider linkage.
+- `Customs/Items/EmptySpecialSauceBottle.cs` — Needs summary covering refill workflow for empty bottles.
+- `Customs/Items/MeatCleaver.cs` — Missing summary describing cleaver capabilities and kill tagging.
+- `Customs/Items/MysteryMeat.cs` — Requires summary highlighting grinder-ready meat flow and processes.
+- `Customs/Items/PoisonBottle.cs` — Needs summary for poison bottle behavior and dedicated provider.
+- `Customs/Items/RottenMysteryMeat.cs` — Lacks summary documenting rotten variant and visual effects.
+
+## Customs / ItemGroups
+- `Customs/ItemGroups/BaggedCorpse.cs` — Entire definition is disabled but still needs summary comments before reactivation.
+- `Customs/ItemGroups/RawHotdog.cs` — Missing summary for recipe composition and conversion rules.
+- `Customs/ItemGroups/RawPottedLobster.cs` — Commented-out implementation lacks required summaries and debug if restored.
+
+## Customs / Dishes
+- `Customs/Dishes/MysteryMeatBurgerDish.cs` — Needs summary articulating unlock purpose and gameplay impact.
+- `Customs/Dishes/MysteryMeatHotdogDish.cs` — Missing summary describing dish unlock flow and requirements.
+- `Customs/Dishes/MysteryMeatPieDish.cs` — Requires summary covering pie unlock configuration.
+- `Customs/Dishes/SpecialSauceDish.cs` — Lacks summary for special sauce unlock metadata.
+
+## Customs / Processes
+- `Customs/Processes/GrindMeat.cs` — Needs summary to describe grinder process registration and localization payloads.
+
+## UnityProject Template Editors
+- `UnityProject - MysteryMeat/Assets/Template/Editor/AssetBundler.cs` — Add summaries for `BuildAssetBundle`, `GetGameObjectPath`, and maintenance menu actions; integrate preference-aware logging if editor tooling should honor mod settings.
+- `UnityProject - MysteryMeat/Assets/Template/Editor/EmptyAtZero_Creator.cs` — Missing summaries for creation helpers invoked from the PlateUp! menu.
+- `UnityProject - MysteryMeat/Assets/Template/Editor/EmptyChildAtGlobalZero_Creator.cs` — Needs summary comments for both menu entry points.
+- `UnityProject - MysteryMeat/Assets/Template/Editor/EmptyChildAtLocalZero_Creator.cs` — Lacks summaries for the local-zero creation commands.
+- `UnityProject - MysteryMeat/Assets/Template/Editor/EmptyCreator.cs` — Requires summaries across helper overloads and should add verbose logging when generating editor prefabs.
+
+Update this list as files are documented and instrumented so the backlog remains accurate.

--- a/Helper.cs
+++ b/Helper.cs
@@ -22,14 +22,14 @@ namespace KitchenMysteryMeat
             // Guard: ensure the asset bundle is available before attempting to load assets from it.
             if (Mod.Bundle == null)
             {
-                DebugLogSystem.LogWarning("Mystery Meat attempted to load a prefab before the asset bundle was initialised.");
+                DebugLogSystem.LogWarning("Attempted to load a prefab before the asset bundle was initialised.");
                 return null;
             }
 
             // Guard: avoid attempting to load assets when the requested name is blank.
             if (string.IsNullOrWhiteSpace(name))
             {
-                DebugLogSystem.LogWarning("Mystery Meat attempted to load a prefab with an empty name from the asset bundle.");
+                DebugLogSystem.LogWarning("Attempted to load a prefab with an empty name from the asset bundle.");
                 return null;
             }
 
@@ -38,7 +38,7 @@ namespace KitchenMysteryMeat
             // Guard: report missing prefabs so configuration issues can be diagnosed quickly.
             if (prefab == null)
             {
-                DebugLogSystem.LogWarning($"Mystery Meat could not locate prefab '{name}' within the asset bundle.");
+                DebugLogSystem.LogWarning($"Could not locate prefab '{name}' within the asset bundle.");
             }
 
             return prefab;

--- a/Mod.cs
+++ b/Mod.cs
@@ -141,7 +141,7 @@ namespace KitchenMysteryMeat
             // Guard: abort runtime registrations when the initialisation failed to acquire assets or preferences.
             if (!isReady)
             {
-                DebugLogSystem.LogError("Mystery Meat initialisation failed; runtime hooks and event subscriptions have been skipped to avoid null reference issues.");
+                DebugLogSystem.LogError("Initialisation failed; runtime hooks and event subscriptions have been skipped to avoid null reference issues.");
             }
             else
             {
@@ -336,7 +336,7 @@ namespace KitchenMysteryMeat
                 }
                 else
                 {
-                    DebugLogSystem.LogError("Mystery Meat could not locate its asset bundle during activation; audio registration will be skipped.");
+                DebugLogSystem.LogError("Could not locate the asset bundle during activation; audio registration will be skipped.");
                 }
             }
 
@@ -368,7 +368,7 @@ namespace KitchenMysteryMeat
             // Guard: ensure runtime dependencies remain available before applying game data modifications.
             if (!IsRuntimeReady())
             {
-                DebugLogSystem.LogWarning("BuildGameDataEvent triggered before Mystery Meat finished initialising; the handler execution has been skipped.");
+                DebugLogSystem.LogWarning("BuildGameDataEvent triggered before initialisation completed; the handler execution has been skipped.");
             }
             else
             {

--- a/MonoBehaviours/PreferenceVolumeAdjuster.cs
+++ b/MonoBehaviours/PreferenceVolumeAdjuster.cs
@@ -4,6 +4,9 @@ using UnityEngine;
 
 namespace KitchenMysteryMeat.MonoBehaviours
 {
+    /// <summary>
+    /// Applies preference-driven volume multipliers to attached sound sources at runtime.
+    /// </summary>
     public class PreferenceVolumeAdjuster : MonoBehaviour
     {
         public string PreferenceID = string.Empty;
@@ -24,7 +27,7 @@ namespace KitchenMysteryMeat.MonoBehaviours
                     {
                         if (!_missingPreferenceManagerLogged)
                         {
-                            DebugLogSystem.LogVerbose("Mystery Meat deferred volume adjustment because preferences are not yet initialised.");
+                            DebugLogSystem.LogVerbose("Deferred volume adjustment because preferences are not yet initialised.");
                             _missingPreferenceManagerLogged = true;
                         }
 

--- a/Patches/LocalViewRouter_Patch.cs
+++ b/Patches/LocalViewRouter_Patch.cs
@@ -7,16 +7,19 @@ using UnityEngine;
 namespace KitchenMysteryMeat.Patches
 {
     [HarmonyPatch]
+    /// <summary>
+    /// Handles suspicion indicator injection by extending the local view router lifecycle.
+    /// </summary>
     static class LocalViewRouter_Patch
     {
-        [HarmonyPatch(typeof(LocalViewRouter), "GetPrefab")]
-        [HarmonyPostfix]
         /// <summary>
         /// Injects the suspicion indicator view onto customer prefabs once the base game provides them.
         /// </summary>
         /// <param name="__instance">The router invoking the hook.</param>
         /// <param name="view_type">The view type being requested.</param>
         /// <param name="__result">The prefab returned by the router.</param>
+        [HarmonyPatch(typeof(LocalViewRouter), "GetPrefab")]
+        [HarmonyPostfix]
         static void GetPrefab_Postfix(ref LocalViewRouter __instance, ViewType view_type, ref GameObject __result)
         {
             // Guard: ensure the asset bundle is available before attempting to instantiate custom indicators.
@@ -24,7 +27,7 @@ namespace KitchenMysteryMeat.Patches
             {
                 if (!_missingBundleWarningLogged)
                 {
-                    DebugLogSystem.LogVerbose("Mystery Meat skipped suspicion indicator injection because the asset bundle is unavailable.");
+                    DebugLogSystem.LogVerbose("Skipped suspicion indicator injection because the asset bundle is unavailable.");
                     _missingBundleWarningLogged = true;
                 }
 
@@ -39,7 +42,7 @@ namespace KitchenMysteryMeat.Patches
                 // Guard: abort when the indicator prefab is missing from the bundle to avoid null references.
                 if (indicatorPrefab == null)
                 {
-                    DebugLogSystem.LogWarning("Mystery Meat could not locate the SuspicionIndicator prefab while injecting customer views.");
+                    DebugLogSystem.LogWarning("Could not locate the SuspicionIndicator prefab while injecting customer views.");
                     return;
                 }
 
@@ -47,6 +50,7 @@ namespace KitchenMysteryMeat.Patches
                 SuspicionIndicatorView indicatorView = indicator.AddComponent<SuspicionIndicatorView>();
                 indicatorView.SuspicionClip = Mod.Bundle.LoadAsset<AudioClip>("suspicion.ogg");
                 indicator.transform.SetParent(__result.transform);
+                DebugLogSystem.LogVerbose($"Attached suspicion indicator view to customer prefab {__result.name}.");
             }
         }
 

--- a/Patches/SoundEventView_Patch.cs
+++ b/Patches/SoundEventView_Patch.cs
@@ -2,6 +2,7 @@
 using Kitchen;
 using Kitchen.Components;
 using KitchenMysteryMeat.MonoBehaviours;
+using KitchenMysteryMeat.Systems.Logging;
 using KitchenMysteryMeat.Views;
 using System;
 using System.Collections.Generic;
@@ -13,9 +14,15 @@ using UnityEngine;
 
 namespace KitchenMysteryMeat.Patches
 {
+    /// <summary>
+    /// Harmonises the sound event view to apply preference-aware volume adjusters to Mystery Meat clips.
+    /// </summary>
     [HarmonyPatch]
     static class SoundEventView_Patch
     {
+        /// <summary>
+        /// Ensures Mystery Meat audio events respect player-configured volume preferences.
+        /// </summary>
         [HarmonyPatch(typeof(SoundEventView), "UpdateData")]
         [HarmonyPrefix]
         static bool UpdateData_Prefix(ref SoundEventView __instance, SoundEventView.ViewData data)
@@ -23,11 +30,13 @@ namespace KitchenMysteryMeat.Patches
             if (data.Event == Mod.AlertSoundEvent)
             {
                 __instance.gameObject.AddComponent<PreferenceVolumeAdjuster>().PreferenceID = Mod.ALERT_VOLUME_ID;
+                DebugLogSystem.LogVerbose("Applied alert volume preference adjuster.");
 
             }
             else if (data.Event == Mod.StabSoundEvent)
             {
                 __instance.gameObject.AddComponent<PreferenceVolumeAdjuster>().PreferenceID = Mod.STAB_VOLUME_ID;
+                DebugLogSystem.LogVerbose("Applied stab volume preference adjuster.");
             }
             return true;
         }

--- a/Systems/AddMessToBottle.cs
+++ b/Systems/AddMessToBottle.cs
@@ -4,30 +4,42 @@ using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Systems
 {
-	[UpdateBefore(typeof(DestroyAfterDuration))]
+    /// <summary>
+    /// Refills or converts poison bottles when appliances complete their filling process.
+    /// </summary>
+    [UpdateBefore(typeof(DestroyAfterDuration))]
     public class AddMessToBottle : GameSystemBase, IModSystem
     {
         private EntityQuery ApplianceQuery;
+
+        /// <summary>
+        /// Builds the query that locates appliances currently filling bottles.
+        /// </summary>
         protected override void Initialise()
         {
             ApplianceQuery = GetEntityQuery(new QueryHelper()
                             .All(typeof(CFillsBottle), typeof(CAppliance), typeof(CTakesDuration), typeof(CBeingActedOnBy)));
         }
 
+        /// <summary>
+        /// Converts empty bottles back into filled bottles when the appliance finishes its duration.
+        /// </summary>
         protected override void OnUpdate()
         {
             using NativeArray<Entity> _appliances = ApplianceQuery.ToEntityArray(Allocator.TempJob);
+
+            // Guard: exit early when there are no active appliances performing bottle fills.
+            if (_appliances.Length == 0)
+            {
+                return;
+            }
 
             foreach (Entity appliance in _appliances)
             {
@@ -36,23 +48,29 @@ namespace KitchenMysteryMeat.Systems
                 DynamicBuffer<CBeingActedOnBy> actors = GetBuffer<CBeingActedOnBy>(appliance);
                 CTakesDuration duration = GetComponent<CTakesDuration>(appliance);
 
+                // Guard: skip appliances that have not completed their work duration.
                 if (!duration.Active || duration.Remaining > 0f)
                 {
+                    DebugLogSystem.LogVerbose($"Skipping appliance {appliance.Index} because the fill process is still running.");
                     continue;
                 }
 
+                // Guard: skip when no actors are currently interacting with the appliance.
                 if (actors.IsEmpty)
                 {
+                    DebugLogSystem.LogVerbose($"Found no interacting actors for appliance {appliance.Index}.");
                     continue;
                 }
 
                 for (int i = 0; i < actors.Length; i++)
                 {
+                    // Guard: ensure the actor exposes an item holder before attempting to refill bottles.
                     if (Require<CItemHolder>(actors[i].Interactor, out var itemHolder))
                     {
                         /*if (GetComponent<CItem>(itemHolder.HeldItem).ID != cFillsBottle.BottleID)
                             continue;*/
 
+                        // Guard: replace empty bottles with their filled counterparts when discovered.
                         if (Require<CEmptyBottle>(itemHolder.HeldItem, out var emptyBottle))
                         {
                             EntityManager.AddComponentData<CChangeItemType>(itemHolder.HeldItem, new CChangeItemType()
@@ -60,20 +78,32 @@ namespace KitchenMysteryMeat.Systems
                                 NewID = emptyBottle.FullBottleID,
                             });
                             EntityManager.RemoveComponent<CEmptyBottle>(itemHolder.HeldItem);
+                            DebugLogSystem.LogVerbose($"Converted empty bottle entity {itemHolder.HeldItem.Index} to full bottle ID {emptyBottle.FullBottleID}.");
                             continue;
                         }
 
-                        if (Require<CLimitedUseBottle>(itemHolder.HeldItem, out var bottle)) 
+                        // Guard: refill partially used bottles by resetting their fill count to the configured limit.
+                        if (Require<CLimitedUseBottle>(itemHolder.HeldItem, out var bottle))
                         {
                             bottle.FillAmount = bottle.Limit;
 
                             if (actors[i].Interactor != Entity.Null)
+                            {
                                 EntityManager.SetComponentData(itemHolder.HeldItem, bottle);
+                            }
+
+                            DebugLogSystem.LogVerbose($"Refilled limited-use bottle entity {itemHolder.HeldItem.Index} to limit {bottle.Limit}.");
                         }
+                    }
+                    else
+                    {
+                        int actorIndex = actors[i].Interactor != Entity.Null ? actors[i].Interactor.Index : -1;
+                        DebugLogSystem.LogWarning($"Encountered actor {actorIndex} without a CItemHolder while refilling bottles on appliance {appliance.Index}.");
                     }
                 }
 
                 EntityManager.RemoveComponent<CFillsBottle>(appliance);
+                DebugLogSystem.LogVerbose($"Cleared CFillsBottle from appliance {appliance.Index} after refilling bottles.");
             }
         }
     }

--- a/Systems/ApplyIllegalSightEffects.cs
+++ b/Systems/ApplyIllegalSightEffects.cs
@@ -14,6 +14,9 @@ using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems
 {
+    /// <summary>
+    /// Applies illegal sight transformation effects at the start of each day.
+    /// </summary>
     public class ApplyIllegalSightEffects : StartOfDaySystem, IModSystem
     {
         /// <summary>
@@ -30,7 +33,7 @@ namespace KitchenMysteryMeat.Systems
             using (NativeArray<Entity> allEntities = query.ToEntityArray(Allocator.Temp))
             {
                 // Log the total number of illegal entities discovered for debugging purposes using the debug helper.
-                DebugLogSystem.LogVerbose($"[ApplyIllegalSightEffects] Processing {allEntities.Length} illegal entities at day start.");
+                DebugLogSystem.LogVerbose($"Processing {allEntities.Length} illegal entities at day start.");
 
                 // Guard: short-circuit when no illegal entities require processing.
                 if (allEntities.Length > 0)
@@ -43,23 +46,23 @@ namespace KitchenMysteryMeat.Systems
                         Entity entity = allEntities[i];
 
                         // Emit a debug line for each entity as it is evaluated.
-                        DebugLogSystem.LogVerbose($"[ApplyIllegalSightEffects] Evaluating entity {entity.Index}.");
+                        DebugLogSystem.LogVerbose($"Evaluating entity {entity.Index}.");
 
                         // Handle illegal items by spawning rotten replacements.
                         if (ctx.Has<CItem>(entity))
                         {
-                            DebugLogSystem.LogVerbose($"[ApplyIllegalSightEffects] Transforming illegal item entity {entity.Index}.");
+                            DebugLogSystem.LogVerbose($"Transforming illegal item entity {entity.Index}.");
                             CorpseEffects.TransformCorpse(ctx, entity);
                         }
                         // Handle illegal appliances that swap to their configured replacements.
                         else if (ctx.Has<CAppliance>(entity))
                         {
-                            DebugLogSystem.LogVerbose($"[ApplyIllegalSightEffects] Replacing illegal appliance entity {entity.Index}.");
+                            DebugLogSystem.LogVerbose($"Replacing illegal appliance entity {entity.Index}.");
                             CorpseEffects.ReplaceWithAppliance(ctx, entity);
                         }
                         else
                         {
-                            DebugLogSystem.LogVerbose($"[ApplyIllegalSightEffects] Entity {entity.Index} lacked item or appliance components.");
+                            DebugLogSystem.LogVerbose($"Entity {entity.Index} lacked item or appliance components.");
                         }
                     }
                 }

--- a/Systems/ApplyIllegalSightOvernightFlags.cs
+++ b/Systems/ApplyIllegalSightOvernightFlags.cs
@@ -3,17 +3,24 @@ using KitchenData;
 using KitchenLib.Utils;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
+using KitchenMysteryMeat.Systems.Logging;
 using System.Collections.Generic;
 using Unity.Collections;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems
 {
+    /// <summary>
+    /// Applies overnight preservation markers to illegal sight holders and manages appliance destruction flags.
+    /// </summary>
     public class ApplyIllegalSightOvernightFlags : GameSystemBase, IModSystem
     {
         private EntityQuery IllegalEntities;
         private EntityQuery HolderPreservers;
 
+        /// <summary>
+        /// Configures queries for illegal entities and holders previously marked for overnight preservation.
+        /// </summary>
         protected override void Initialise()
         {
             base.Initialise();
@@ -29,6 +36,9 @@ namespace KitchenMysteryMeat.Systems
             });
         }
 
+        /// <summary>
+        /// Applies overnight preservation based on the persistent corpses status and cleans up stale markers.
+        /// </summary>
         protected override void OnUpdate()
         {
             bool persistent = HasStatus((RestaurantStatus)VariousUtils.GetID("persistentcorpses"));
@@ -36,34 +46,57 @@ namespace KitchenMysteryMeat.Systems
             HashSet<Entity> holdersWithIllegalItems = persistent ? new HashSet<Entity>() : null;
 
             using NativeArray<Entity> illegals = IllegalEntities.ToEntityArray(Allocator.Temp);
+
+            // Guard: log when no illegal entities were discovered during the overnight evaluation.
+            if (illegals.Length == 0)
+            {
+                DebugLogSystem.LogVerbose("Found no illegal entities to process during overnight cleanup.");
+            }
+
             for (int i = 0; i < illegals.Length; ++i)
             {
                 Entity entity = illegals[i];
 
+                // Guard: when persistence is enabled, ensure holders storing illegal items retain their contents overnight.
                 if (persistent && EntityManager.HasComponent<CItem>(entity))
                 {
                     HandleHeldItemPreservation(entity, holdersWithIllegalItems);
                 }
 
+                // Always evaluate appliance behaviour to ensure destruction flags remain accurate.
                 HandleApplianceOvernightBehaviour(entity, persistent);
             }
 
             CleanupHolderPreservers(persistent, holdersWithIllegalItems);
         }
 
+        /// <summary>
+        /// Ensures holders carrying illegal items retain overnight preservation when persistence is enabled.
+        /// </summary>
         private void HandleHeldItemPreservation(Entity item, HashSet<Entity> holdersWithIllegalItems)
         {
+            // Guard: skip when persistence tracking is not active for holders.
             if (holdersWithIllegalItems == null)
+            {
                 return;
+            }
 
-            if (!EntityManager.HasComponent<CHeldBy>(item))
-                return;
+            // Guard: only proceed when the item is currently held by another entity.
+                if (!EntityManager.HasComponent<CHeldBy>(item))
+                {
+                    DebugLogSystem.LogVerbose($"Skipped illegal item {item.Index} because it is not held by an appliance.");
+                    return;
+                }
 
             CHeldBy heldBy = EntityManager.GetComponentData<CHeldBy>(item);
             Entity holder = heldBy.Holder;
 
+            // Guard: verify the holder is a valid appliance before adding overnight preservation.
             if (holder == Entity.Null || !EntityManager.HasComponent<CAppliance>(holder))
+            {
+                DebugLogSystem.LogWarning($"Detected illegal item {item.Index} held by invalid entity {holder.Index}; preservation skipped.");
                 return;
+            }
 
             holdersWithIllegalItems.Add(holder);
 
@@ -71,6 +104,7 @@ namespace KitchenMysteryMeat.Systems
             if (!hadPreserver)
             {
                 EntityManager.AddComponentData(holder, new CPreservesContentsOvernight());
+                DebugLogSystem.LogVerbose($"Added overnight preservation to holder {holder.Index}.");
             }
 
             if (EntityManager.HasComponent<CIllegalSightHolderPreserved>(holder))
@@ -82,6 +116,7 @@ namespace KitchenMysteryMeat.Systems
                     {
                         marker.AddedPreserver = true;
                         EntityManager.SetComponentData(holder, marker);
+                        DebugLogSystem.LogVerbose($"Updated holder preservation marker for entity {holder.Index} to reflect added preserver.");
                     }
                 }
             }
@@ -91,33 +126,48 @@ namespace KitchenMysteryMeat.Systems
                 {
                     AddedPreserver = !hadPreserver
                 });
+                DebugLogSystem.LogVerbose($"Created preservation marker for holder {holder.Index}.");
             }
         }
 
+        /// <summary>
+        /// Removes stale preservation markers from holders that no longer require overnight protection.
+        /// </summary>
         private void CleanupHolderPreservers(bool persistent, HashSet<Entity> holdersWithIllegalItems)
         {
             using NativeArray<Entity> holders = HolderPreservers.ToEntityArray(Allocator.Temp);
             if (holders.Length == 0)
+            {
                 return;
+            }
 
             for (int i = holders.Length - 1; i >= 0; --i)
             {
                 Entity holder = holders[i];
 
+                // Guard: retain the preserver when persistence is active and the holder still contains illegal items.
                 if (persistent && holdersWithIllegalItems != null && holdersWithIllegalItems.Contains(holder))
+                {
+                    DebugLogSystem.LogVerbose($"Retained overnight preservation for holder {holder.Index} because persistent corpses are enabled.");
                     continue;
+                }
 
                 CIllegalSightHolderPreserved marker = EntityManager.GetComponentData<CIllegalSightHolderPreserved>(holder);
 
                 if (marker.AddedPreserver && EntityManager.HasComponent<CPreservesContentsOvernight>(holder))
                 {
                     EntityManager.RemoveComponent<CPreservesContentsOvernight>(holder);
+                    DebugLogSystem.LogVerbose($"Removed overnight preserver from holder {holder.Index}.");
                 }
 
                 EntityManager.RemoveComponent<CIllegalSightHolderPreserved>(holder);
+                DebugLogSystem.LogVerbose($"Cleared preservation marker from holder {holder.Index}.");
             }
         }
 
+        /// <summary>
+        /// Updates appliance overnight behaviour, ensuring destruction flags align with persistence settings.
+        /// </summary>
         private void HandleApplianceOvernightBehaviour(Entity entity, bool persistent)
         {
             if (!EntityManager.HasComponent<CAppliance>(entity))
@@ -137,6 +187,7 @@ namespace KitchenMysteryMeat.Systems
                     if (hasDestroyMarker)
                     {
                         EntityManager.RemoveComponent<CDestroyApplianceAtNight>(entity);
+                        DebugLogSystem.LogVerbose($"Removed nighttime destruction from appliance {entity.Index} because it transforms on day start.");
                     }
                 }
 
@@ -146,6 +197,7 @@ namespace KitchenMysteryMeat.Systems
             if (!hasDestroyMarker)
             {
                 EntityManager.AddComponentData(entity, new CDestroyApplianceAtNight());
+                DebugLogSystem.LogVerbose($"Marked appliance {entity.Index} for destruction at night.");
             }
         }
     }

--- a/Systems/ApplyPersistentPortions.cs
+++ b/Systems/ApplyPersistentPortions.cs
@@ -2,21 +2,23 @@
 using KitchenData;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using Unity.Collections;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems
 {
     //[UpdateAfter(typeof(ObjectsSplittableView.UpdateView))]
+    /// <summary>
+    /// Restores splittable item portion counts from persisted data when a day starts.
+    /// </summary>
     public class ApplyPersistentPortions : DaySystem, IModSystem
     {
         EntityQuery Query;
 
+        /// <summary>
+        /// Builds the query that locates splittable items with persisted portion data.
+        /// </summary>
         protected override void Initialise()
         {
             base.Initialise();
@@ -26,9 +28,18 @@ namespace KitchenMysteryMeat.Systems
                             .None(typeof(CChangeItemType)));
         }
 
+        /// <summary>
+        /// Applies persisted portion values to the splittable items and removes the persistence marker.
+        /// </summary>
         protected override void OnUpdate()
         {
             using NativeArray<Entity> _splittableItems = Query.ToEntityArray(Allocator.Temp);
+
+            // Guard: exit when no splittable items require persistence application.
+            if (_splittableItems.Length == 0)
+            {
+                return;
+            }
 
             for (int i = _splittableItems.Length - 1; i >= 0; i--)
             {
@@ -42,6 +53,7 @@ namespace KitchenMysteryMeat.Systems
                 Set<CSplittableItem>(splittableItem, cSplittableItem);
 
                 EntityManager.RemoveComponent<CPersistPortions>(splittableItem);
+                DebugLogSystem.LogVerbose($"Restored {cPersistPortions.RemainingCount}/{cPersistPortions.TotalCount} portions for item {splittableItem.Index}.");
             }
         }
     }

--- a/Systems/AttachTrashBagComponents.cs
+++ b/Systems/AttachTrashBagComponents.cs
@@ -3,19 +3,21 @@ using KitchenData;
 using KitchenLib.Utils;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using Unity.Collections;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems
 {
+    /// <summary>
+    /// Ensures trash bags expose item storage buffers so they can hold corpses safely.
+    /// </summary>
     public class AttachTrashBagComponents : GameSystemBase, IModSystem
     {
         private EntityQuery TrashBags;
+        /// <summary>
+        /// Builds the query that locates trash bags lacking item storage components.
+        /// </summary>
         protected override void Initialise()
         {
             TrashBags = GetEntityQuery(new QueryHelper()
@@ -23,9 +25,18 @@ namespace KitchenMysteryMeat.Systems
                             .None(typeof(CItemStorage)));
         }
 
+        /// <summary>
+        /// Adds storage capacity and buffers to trash bags so they can store corpses between uses.
+        /// </summary>
         protected override void OnUpdate()
         {
             using NativeArray<Entity> _trashBags = TrashBags.ToEntityArray(Allocator.Temp);
+
+            // Guard: exit when no trash bags require component attachment this frame.
+            if (_trashBags.Length == 0)
+            {
+                return;
+            }
 
             foreach (Entity trashBag in _trashBags)
             {
@@ -34,6 +45,7 @@ namespace KitchenMysteryMeat.Systems
                     Capacity = 1
                 });
                 EntityManager.AddBuffer<CItemStored>(trashBag);
+                DebugLogSystem.LogVerbose($"Provisioned storage for trash bag {trashBag.Index}.");
             }
         }
     }

--- a/Systems/CreateNewProcessSpills.cs
+++ b/Systems/CreateNewProcessSpills.cs
@@ -1,30 +1,41 @@
 ﻿using Kitchen;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Systems
 {
+    /// <summary>
+    /// Generates mess requests while certain processes run on held items, simulating messy preparation steps.
+    /// </summary>
     public class CreateNewProcessSpills : GameSystemBase, IModSystem
     {
         EntityQuery ItemsUndergoingProcess;
 
+        /// <summary>
+        /// Builds the query that locates items undergoing processes capable of spawning spills.
+        /// </summary>
         protected override void Initialise()
         {
             base.Initialise();
             ItemsUndergoingProcess = GetEntityQuery(typeof(CItem), typeof(CHeldBy), typeof(CProcessCausesSpill), typeof(CItemUndergoingProcess));
         }
 
+        /// <summary>
+        /// Spawns mess requests when applicable processes meet their randomised spill chance thresholds.
+        /// </summary>
         protected override void OnUpdate()
         {
             using NativeArray<Entity> _items = ItemsUndergoingProcess.ToEntityArray(Allocator.Temp);
+
+            // Guard: exit early when no items are currently being processed.
+            if (_items.Length == 0)
+            {
+                return;
+            }
 
             foreach (Entity item in _items)
             {
@@ -33,15 +44,26 @@ namespace KitchenMysteryMeat.Systems
                 CHeldBy cHeldBy = EntityManager.GetComponentData<CHeldBy>(item);
                 CPosition cPosition;
 
+                // Guard: obtain the holder position to anchor potential spill requests.
                 if (!Require<CPosition>(cHeldBy.Holder, out cPosition))
+                {
+                    DebugLogSystem.LogWarning($"Unable to resolve holder position for item {item.Index}; skipping spill generation.");
                     continue;
+                }
 
+                // Guard: ensure the current process matches the configured spill-causing process.
                 if (cItemUndergoingProcess.Process != cProcessCausesSpill.Process)
+                {
                     continue;
+                }
 
+                // Guard: skip spill generation once the process nearly completes to avoid late mess bursts.
                 if (cItemUndergoingProcess.Progress >= 0.9)
+                {
                     continue;
+                }
 
+                // Guard: roll against the configured spill rate to determine whether a mess should spawn.
                 if (UnityEngine.Random.value < cProcessCausesSpill.Rate * Time.DeltaTime)
                 {
                     Entity spill = EntityManager.CreateEntity();
@@ -51,6 +73,7 @@ namespace KitchenMysteryMeat.Systems
                         OverwriteOtherMesses = cProcessCausesSpill.OverwriteOtherMesses
                     });
                     EntityManager.AddComponentData<CPosition>(spill, cPosition);
+                    DebugLogSystem.LogVerbose($"Generated mess request {spill.Index} at position {cPosition.Position} for item {item.Index}.");
                 }
             }
         }

--- a/Systems/DestroyEmptyCustomerGroups.cs
+++ b/Systems/DestroyEmptyCustomerGroups.cs
@@ -1,22 +1,24 @@
 ﻿using Kitchen;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using Unity.Collections;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems
 {
+    /// <summary>
+    /// Cleans up customer group entities after all members have fled and no alerts remain in transit.
+    /// </summary>
     [UpdateInGroup(typeof(DestructionGroup)), UpdateAfter(typeof(KillCustomers))]
     public class DestroyEmptyCustomerGroups : DaySystem, IModSystem
     {
         EntityQuery CustomerGroups;
         EntityQuery AlertedDiners;
 
+        /// <summary>
+        /// Builds queries used to locate customer groups and alerted diners for later evaluation.
+        /// </summary>
         protected override void Initialise()
         {
             base.Initialise();
@@ -26,6 +28,9 @@ namespace KitchenMysteryMeat.Systems
                 .All(typeof(CAlertedCustomer), typeof(CBelongsToGroup)));
         }
 
+        /// <summary>
+        /// Destroys empty groups whose members have either fled or been fully cleaned up.
+        /// </summary>
         protected override void OnUpdate()
         {
             using NativeArray<Entity> _customerGroups = CustomerGroups.ToEntityArray(Allocator.Temp);
@@ -35,8 +40,10 @@ namespace KitchenMysteryMeat.Systems
             {
                 Entity customerGroup = _customerGroups[i];
 
+                // Guard: ensure the group exposes its membership buffer before attempting cleanup.
                 if (RequireBuffer<CGroupMember>(customerGroup, out DynamicBuffer<CGroupMember> groupMembers))
                 {
+                    // Guard: only destroy the group when no members remain.
                     if (groupMembers.Length <= 0)
                     {
                         bool hasAlertedMembersInFlight = false;
@@ -50,18 +57,27 @@ namespace KitchenMysteryMeat.Systems
                             }
                         }
 
+                        // Guard: skip destruction when alerted customers are still leaving the restaurant.
                         if (hasAlertedMembersInFlight)
                         {
+                            DebugLogSystem.LogVerbose($"Deferred destruction for group {customerGroup.Index} because alerted diners remain in flight.");
                             continue;
                         }
 
+                        // Guard: destroy any indicator entity before removing the group itself.
                         if (Require<CHasIndicator>(customerGroup, out CHasIndicator cHasIndicator))
                         {
                             EntityManager.DestroyEntity(cHasIndicator.Indicator);
+                            DebugLogSystem.LogVerbose($"Removed indicator {cHasIndicator.Indicator.Index} prior to destroying group {customerGroup.Index}.");
                         }
 
                         EntityManager.DestroyEntity(customerGroup);
+                        DebugLogSystem.LogVerbose($"Destroyed empty group {customerGroup.Index}.");
                     }
+                }
+                else
+                {
+                    DebugLogSystem.LogWarning($"Could not access CGroupMember buffer for group {customerGroup.Index}; destruction skipped.");
                 }
             }
         }

--- a/Systems/EscapedGameOver.cs
+++ b/Systems/EscapedGameOver.cs
@@ -2,11 +2,7 @@
 using KitchenData;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
@@ -14,11 +10,17 @@ using UnityEngine.UI;
 
 namespace KitchenMysteryMeat.Systems
 {
+    /// <summary>
+    /// Triggers the game-over condition when alerted customers successfully flee the restaurant.
+    /// </summary>
     public class EscapedGameOver : GameSystemBase, IModSystem
     {
         EntityQuery Customers;
         private ComponentType? ReachedDestinationComponentType;
 
+        /// <summary>
+        /// Builds the query that tracks fleeing customers and resolves the destination component metadata.
+        /// </summary>
         protected override void Initialise()
         {
             base.Initialise();
@@ -28,11 +30,26 @@ namespace KitchenMysteryMeat.Systems
                             .All(typeof(CPosition), typeof(CCustomer), typeof(CCustomerLeaving), typeof(CAlertedCustomer)));
 
             ReachedDestinationComponentType = TryGetReachedDestinationComponentType();
+
+            // Guard: notify when the destination component could not be located for diagnostic purposes.
+            if (!ReachedDestinationComponentType.HasValue)
+            {
+                DebugLogSystem.LogWarning("Could not resolve CReachedDestination; falling back to distance checks.");
+            }
         }
 
+        /// <summary>
+        /// Ends the run when an alerted customer reaches the escape boundary.
+        /// </summary>
         protected override void OnUpdate()
         {
             using NativeArray<Entity> _customers = Customers.ToEntityArray(Allocator.Temp);
+
+            // Guard: exit when no alerted customers are currently fleeing the restaurant.
+            if (_customers.Length == 0)
+            {
+                return;
+            }
 
             for (int i = 0; i < _customers.Length; i++)
             {
@@ -55,11 +72,15 @@ namespace KitchenMysteryMeat.Systems
                     // End game if exited
                     EntityManager.CreateEntity(typeof(CLoseLifeEvent));
                     EntityManager.DestroyEntity(customer);
+                    DebugLogSystem.LogWarning($"Triggered game over because alerted customer {customer.Index} exited the restaurant.");
                     break;
                 }
             }
         }
 
+        /// <summary>
+        /// Locates the destination component type, supporting multiple assembly locations.
+        /// </summary>
         private static ComponentType? TryGetReachedDestinationComponentType()
         {
             Type type = Type.GetType("Kitchen.CReachedDestination, KitchenMode")
@@ -68,6 +89,7 @@ namespace KitchenMysteryMeat.Systems
 
             if (type == null)
             {
+                DebugLogSystem.LogWarning("Could not locate Kitchen.CReachedDestination in any known assembly.");
                 return null;
             }
 

--- a/Systems/ISeeDeadPeople.cs
+++ b/Systems/ISeeDeadPeople.cs
@@ -10,14 +10,21 @@ using Unity.Entities;
 using UnityEngine.UI;
 using UnityEngine;
 using KitchenMysteryMeat.Components;
+using KitchenMysteryMeat.Systems.Logging;
 
 namespace KitchenMysteryMeat.Systems
 {
+    /// <summary>
+    /// Monitors customers and flags them as suspicious when they observe illegal sights within their room.
+    /// </summary>
     public class ISeeDeadPeople : GenericSystemBase, IModSystem
     {
         EntityQuery Customers;
         EntityQuery IllegalEntities;
 
+        /// <summary>
+        /// Builds queries for customers and illegal sight entities to support suspicion updates.
+        /// </summary>
         protected override void Initialise()
         {
             base.Initialise();
@@ -32,6 +39,9 @@ namespace KitchenMysteryMeat.Systems
                             .All(typeof(CIllegalSight)));
         }
 
+        /// <summary>
+        /// Updates customer suspicion references based on line-of-sight checks against illegal entities.
+        /// </summary>
         protected override void OnUpdate()
         {
             using NativeArray<Entity> _customers = Customers.ToEntityArray(Allocator.Temp);
@@ -43,14 +53,16 @@ namespace KitchenMysteryMeat.Systems
                 CPosition customerPosition = GetComponent<CPosition>(customer);
                 CSuspicionIndicator cSuspicionIndicator = GetComponent<CSuspicionIndicator>(customer);
 
-
                 foreach (Entity illegalEntity in _illegalEntities)
                 {
                     CPosition illegalEntityPos;
                     if (!Require<CPosition>(illegalEntity, out illegalEntityPos))
                     {
                         if (Require<CHeldBy>(illegalEntity, out CHeldBy cHeldBy) && !Require<CPosition>(cHeldBy.Holder, out illegalEntityPos))
+                        {
+                            DebugLogSystem.LogWarning($"Could not resolve position for held illegal entity {illegalEntity.Index}.");
                             continue;
+                        }
                     }
 
                     // Checking if illegal entity is in customer's view
@@ -66,6 +78,7 @@ namespace KitchenMysteryMeat.Systems
                             // Run away!
                             cSuspicionIndicator.SeenIllegalThing = illegalEntity;
                             EntityManager.SetComponentData<CSuspicionIndicator>(customer, cSuspicionIndicator);
+                            DebugLogSystem.LogVerbose($"Flagged customer {customer.Index} after spotting illegal entity {illegalEntity.Index}.");
                             continue;
                         }
                     }
@@ -74,6 +87,7 @@ namespace KitchenMysteryMeat.Systems
                     {
                         cSuspicionIndicator.SeenIllegalThing = null;
                         EntityManager.SetComponentData<CSuspicionIndicator>(customer, cSuspicionIndicator);
+                        DebugLogSystem.LogVerbose($"Cleared illegal sight reference for customer {customer.Index}.");
                     }
 
                 }

--- a/Systems/KillCustomers.cs
+++ b/Systems/KillCustomers.cs
@@ -49,7 +49,7 @@ namespace KitchenMysteryMeat.Systems
             EntityContext ctx = new EntityContext(EntityManager);
 
             // Announce the number of slain customers being processed to aid situational awareness.
-            DebugLogSystem.LogVerbose($"[KillCustomers] Processing {_customers.Length} murdered customers.");
+            DebugLogSystem.LogVerbose($"Processing {_customers.Length} murdered customers.");
 
             // Iterate through each dead customer to orchestrate cleanup and corpse creation.
             for (int i = 0; i < _customers.Length; i++)
@@ -60,21 +60,21 @@ namespace KitchenMysteryMeat.Systems
                 CKilled cKilled = EntityManager.GetComponentData<CKilled>(customer);
 
                 // Provide breadcrumbs for each customer so verbose logs expose bloody state.
-                DebugLogSystem.LogVerbose($"[KillCustomers] Handling customer {customer.Index} (bloody: {cKilled.Bloody}).");
+                DebugLogSystem.LogVerbose($"Handling customer {customer.Index} (bloody: {cKilled.Bloody}).");
 
                 CreateCorpse(ctx, customerPosition, cKilled.Bloody);
 
                 // Ensure the customer still references a dining group before attempting removal.
                 if (!Require(customer, out CBelongsToGroup belongsToGroup))
                 {
-                    DebugLogSystem.LogWarning($"[KillCustomers] Customer {customer.Index} missing CBelongsToGroup; skipping group cleanup.");
+                    DebugLogSystem.LogWarning($"Customer {customer.Index} missing CBelongsToGroup; skipping group cleanup.");
                     continue;
                 }
 
                 // Confirm the dining group exposes its member buffer so we can excise the victim.
                 if (!RequireBuffer(belongsToGroup.Group, out DynamicBuffer<CGroupMember> groupMembers))
                 {
-                    DebugLogSystem.LogWarning($"[KillCustomers] Group {belongsToGroup.Group.Index} missing CGroupMember buffer for customer {customer.Index}.");
+                    DebugLogSystem.LogWarning($"Group {belongsToGroup.Group.Index} missing CGroupMember buffer for customer {customer.Index}.");
                     continue;
                 }
 
@@ -106,7 +106,7 @@ namespace KitchenMysteryMeat.Systems
                 }
                 else
                 {
-                    DebugLogSystem.LogWarning($"[KillCustomers] Group {belongsToGroup.Group.Index} missing CWaitingForItem buffer; orders may remain for customer {customer.Index}.");
+                    DebugLogSystem.LogWarning($"Group {belongsToGroup.Group.Index} missing CWaitingForItem buffer; orders may remain for customer {customer.Index}.");
                 }
             }
 
@@ -135,7 +135,7 @@ namespace KitchenMysteryMeat.Systems
             // Skip gore generation when the victim was clean.
             if (!bloody)
             {
-                DebugLogSystem.LogVerbose("[KillCustomers] Corpse spawned without blood spills.");
+                DebugLogSystem.LogVerbose("Corpse spawned without blood spills.");
                 return;
             }
 
@@ -165,7 +165,7 @@ namespace KitchenMysteryMeat.Systems
             }
 
             // Record how many spills were produced to help diagnose performance impact.
-            DebugLogSystem.LogVerbose($"[KillCustomers] Generated {spillsCreated} blood spills for corpse at {cPosition.Position}.");
+            DebugLogSystem.LogVerbose($"Generated {spillsCreated} blood spills for corpse at {cPosition.Position}.");
         }
     }
 }

--- a/Systems/KillInteraction.cs
+++ b/Systems/KillInteraction.cs
@@ -4,16 +4,15 @@ using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using Unity.Collections;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems
 {
+    /// <summary>
+    /// Enables tools that kill customers to apply the death state through player interactions.
+    /// </summary>
     [UpdateInGroup(typeof(LowPriorityInteractionGroup), OrderFirst = true)]
     public class KillInteraction : ItemInteractionSystem, IModSystem
     {
@@ -21,17 +20,32 @@ namespace KitchenMysteryMeat.Systems
 
         protected override bool RequirePress => false;
 
+        /// <summary>
+        /// Determines whether the kill interaction is valid for the current participants.
+        /// </summary>
         protected override bool IsPossible(ref InteractionData data)
         {
             CToolUser ctoolUser;
 
-            return Has<CCustomer>(data.Target) && Require<CToolUser>(data.Interactor, out ctoolUser) && Has<CKillsCustomer>(ctoolUser.CurrentTool) && !Has<CKilled>(data.Target);
+            bool canKill = Has<CCustomer>(data.Target) && Require<CToolUser>(data.Interactor, out ctoolUser) && Has<CKillsCustomer>(ctoolUser.CurrentTool) && !Has<CKilled>(data.Target);
+
+            // Guard: emit diagnostics when the interaction cannot proceed.
+            if (!canKill)
+            {
+                DebugLogSystem.LogVerbose("Kill interaction deemed impossible due to missing components or existing CKilled state.");
+            }
+
+            return canKill;
         }
 
+        /// <summary>
+        /// Applies the kill effect, tagging the target and playing the configured stab sound.
+        /// </summary>
         protected override void Perform(ref InteractionData data)
         {
             CSoundEvent.Create(EntityManager, Mod.StabSoundEvent);
             EntityManager.AddComponentData<CKilled>(data.Target, new CKilled() { Bloody = true });
+            DebugLogSystem.LogVerbose($"Marked customer {data.Target.Index} as killed via interaction.");
         }
     }
 }

--- a/Systems/Logging/DebugLogSystem.cs
+++ b/Systems/Logging/DebugLogSystem.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
 using KitchenLib.Logging;
 using KitchenMysteryMeat.Enums;
 using UnityEngine;
@@ -46,7 +49,7 @@ namespace KitchenMysteryMeat.Systems.Logging
             DebugLogLevel activeLevel = GetActiveDebugLogLevel();
 
             // Compute the formatted message once so that both logging paths share the same output.
-            string formattedMessage = FormatMessage(message, activeLevel >= DebugLogLevel.On);
+            string formattedMessage = FormatMessage(message, activeLevel >= DebugLogLevel.On, false);
 
             // Guard: log informational output through the Kitchen logger when it is available.
             if (logger != null)
@@ -75,12 +78,12 @@ namespace KitchenMysteryMeat.Systems.Logging
             // Guard: log warning output through the Kitchen logger when available.
             if (logger != null && activeLevel >= DebugLogLevel.On)
             {
-                logger.LogWarning(FormatMessage(message, includeStackTrace));
+                logger.LogWarning(FormatMessage(message, includeStackTrace, true));
             }
             else if (activeLevel >= DebugLogLevel.On)
             {
                 // Guard: fall back to Unity diagnostics when the Kitchen logger is unavailable.
-                Debug.LogWarning(FormatMessage(message, includeStackTrace));
+                Debug.LogWarning(FormatMessage(message, includeStackTrace, true));
             }
         }
 
@@ -99,12 +102,12 @@ namespace KitchenMysteryMeat.Systems.Logging
             // Guard: emit error output through the Kitchen logger when available.
             if (logger != null)
             {
-                logger.LogError(FormatMessage(message, includeStackTrace));
+                logger.LogError(FormatMessage(message, includeStackTrace, true));
             }
             else
             {
                 // Guard: fall back to Unity diagnostics when the Kitchen logger is unavailable.
-                Debug.LogError(FormatMessage(message, includeStackTrace));
+                Debug.LogError(FormatMessage(message, includeStackTrace, true));
             }
         }
 
@@ -122,7 +125,7 @@ namespace KitchenMysteryMeat.Systems.Logging
             if (activeLevel >= DebugLogLevel.Verbose)
             {
                 // Verbose logging always includes the stack trace to maximise diagnostic value.
-                string formattedMessage = FormatMessage(message, true);
+                string formattedMessage = FormatMessage(message, true, true);
 
                 // Guard: emit verbose output using the Kitchen logger when available.
                 if (logger != null)
@@ -177,16 +180,26 @@ namespace KitchenMysteryMeat.Systems.Logging
         /// <param name="message">The message to format.</param>
         /// <param name="includeStackTrace">A value indicating whether a stack trace should be appended.</param>
         /// <returns>The formatted message ready for logging.</returns>
-        private static string FormatMessage(string message, bool includeStackTrace)
+        private static string FormatMessage(string message, bool includeStackTrace, bool includePrefix)
         {
             // Default null messages to an empty string before formatting output for the logger.
             string formattedMessage = message ?? string.Empty;
+
+            // Append a source prefix when required to support quicker log triage.
+            if (includePrefix)
+            {
+                string prefix = GetLogSourcePrefix();
+                if (!string.IsNullOrEmpty(prefix) && !formattedMessage.StartsWith(prefix, StringComparison.Ordinal))
+                {
+                    formattedMessage = $"{prefix} {formattedMessage}";
+                }
+            }
 
             // Append the stack trace when verbose diagnostics are requested.
             if (includeStackTrace)
             {
                 // Generate a stack trace that skips the logging helper frames for clarity.
-                string stackTrace = new System.Diagnostics.StackTrace(2, true).ToString();
+                string stackTrace = new StackTrace(2, true).ToString();
 
                 // Append the stack trace only when the generated output contains meaningful content.
                 if (!string.IsNullOrWhiteSpace(stackTrace))
@@ -196,6 +209,39 @@ namespace KitchenMysteryMeat.Systems.Logging
             }
 
             return formattedMessage;
+        }
+
+        /// <summary>
+        /// Computes a standardised prefix containing the originating file name when available.
+        /// </summary>
+        /// <returns>The formatted prefix ready for inclusion in log messages.</returns>
+        private static string GetLogSourcePrefix()
+        {
+            const string defaultPrefix = "[MysteryMeat]";
+
+            StackTrace trace = new StackTrace(3, true);
+            StackFrame frame = trace.GetFrame(0);
+
+            if (frame != null)
+            {
+                string fileName = frame.GetFileName();
+                if (!string.IsNullOrEmpty(fileName))
+                {
+                    string shortName = Path.GetFileName(fileName);
+                    if (!string.IsNullOrEmpty(shortName))
+                    {
+                        return $"[{shortName}]";
+                    }
+                }
+
+                MethodBase method = frame.GetMethod();
+                if (method?.DeclaringType != null)
+                {
+                    return $"[{method.DeclaringType.Name}]";
+                }
+            }
+
+            return defaultPrefix;
         }
     }
 }

--- a/Systems/MarkGroundMeat.cs
+++ b/Systems/MarkGroundMeat.cs
@@ -3,29 +3,41 @@ using KitchenData;
 using KitchenLib.Utils;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using Unity.Collections;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems
 {
     [UpdateInGroup(typeof(ApplianceProcessReactionGroup))]
+    /// <summary>
+    /// Clears grindable flags from items once a meat grinder finishes processing them.
+    /// </summary>
     public class MarkGroundMeat : GameSystemBase, IModSystem
     {
         private EntityQuery Appliances;
+
+        /// <summary>
+        /// Builds the query that identifies meat grinders completing their configured process.
+        /// </summary>
         protected override void Initialise()
         {
             Appliances = GetEntityQuery(new QueryHelper()
                             .All(typeof(CMeatGrinder), typeof(CCompletedProcess), typeof(CItemHolder)));
         }
 
+        /// <summary>
+        /// Removes the grindable marker from held items when the grinder completes its grind process.
+        /// </summary>
         protected override void OnUpdate()
         {
             using NativeArray<Entity> _appliances = Appliances.ToEntityArray(Allocator.TempJob);
+
+            // Guard: exit early when no grinders completed their process this tick.
+            if (_appliances.Length == 0)
+            {
+                return;
+            }
 
             foreach (Entity appliance in _appliances)
             {
@@ -33,12 +45,21 @@ namespace KitchenMysteryMeat.Systems
                 CMeatGrinder cMeatGrinder = EntityManager.GetComponentData<CMeatGrinder>(appliance);
                 CItemHolder cItemHolder = EntityManager.GetComponentData<CItemHolder>(appliance);
 
+                // Guard: only react when the completed process matches the grinder's configured process.
                 if (cCompletedProcess.Process == cMeatGrinder.GrindProcess)
                 {
+                    DebugLogSystem.LogVerbose($"Evaluating grinder {appliance.Index} for held item cleanup.");
+
+                    // Guard: remove the grindable marker when the held item no longer requires grinding.
                     if (Has<CGrindable>(cItemHolder.HeldItem))
                     {
                         EntityManager.RemoveComponent<CGrindable>(cItemHolder.HeldItem);
+                        DebugLogSystem.LogVerbose($"Cleared CGrindable from item {cItemHolder.HeldItem.Index} after grinding.");
                     }
+                }
+                else
+                {
+                    DebugLogSystem.LogVerbose($"Skipped appliance {appliance.Index} because process {cCompletedProcess.Process} does not match grinder configuration {cMeatGrinder.GrindProcess}.");
                 }
             }
         }

--- a/Systems/PoisonInteraction.cs
+++ b/Systems/PoisonInteraction.cs
@@ -31,12 +31,12 @@ namespace KitchenMysteryMeat.Systems
             {
                 if (!hasPlayerHolder)
                 {
-                    DebugLogSystem.LogWarning("[PoisonInteraction:IsPossible] Player holder missing while evaluating poison swap.");
+                    DebugLogSystem.LogWarning("Player holder missing while evaluating poison swap.");
                 }
 
                 if (!hasApplianceHolder)
                 {
-                    DebugLogSystem.LogWarning("[PoisonInteraction:IsPossible] Appliance holder missing while evaluating poison swap.");
+                    DebugLogSystem.LogWarning("Appliance holder missing while evaluating poison swap.");
                 }
             }
 
@@ -48,18 +48,18 @@ namespace KitchenMysteryMeat.Systems
             bool isPossible = false;
 
             // Evaluate whether the player can poison the appliance-held item via their bottle.
-            DebugLogSystem.LogVerbose("[PoisonInteraction:IsPossible] Checking player-supplied poison path.");
+            DebugLogSystem.LogVerbose("Checking player-supplied poison path.");
             if (playerProvidesPoison && applianceHasEligibleItem)
             {
-                DebugLogSystem.LogVerbose("[PoisonInteraction:IsPossible] Player bottle can contaminate the appliance-held item.");
+                DebugLogSystem.LogVerbose("Player bottle can contaminate the appliance-held item.");
                 isPossible = true;
             }
 
             // Evaluate whether the appliance can poison the player-held item via its bottle.
-            DebugLogSystem.LogVerbose("[PoisonInteraction:IsPossible] Checking appliance-supplied poison path.");
+            DebugLogSystem.LogVerbose("Checking appliance-supplied poison path.");
             if (!isPossible && applianceProvidesPoison && playerHasEligibleItem)
             {
-                DebugLogSystem.LogVerbose("[PoisonInteraction:IsPossible] Appliance bottle can contaminate the player-held item.");
+                DebugLogSystem.LogVerbose("Appliance bottle can contaminate the player-held item.");
                 isPossible = true;
             }
 
@@ -83,12 +83,12 @@ namespace KitchenMysteryMeat.Systems
             {
                 if (!hasPlayerHolder)
                 {
-                    DebugLogSystem.LogWarning("[PoisonInteraction:Perform] Player holder missing while attempting poison swap.");
+                    DebugLogSystem.LogWarning("Player holder missing while attempting poison swap.");
                 }
 
                 if (!hasApplianceHolder)
                 {
-                    DebugLogSystem.LogWarning("[PoisonInteraction:Perform] Appliance holder missing while attempting poison swap.");
+                    DebugLogSystem.LogWarning("Appliance holder missing while attempting poison swap.");
                 }
 
                 return;
@@ -102,22 +102,22 @@ namespace KitchenMysteryMeat.Systems
             bool poisonApplied = false;
 
             // Apply poison when the player donates a bottle to contaminate the appliance-held item.
-            DebugLogSystem.LogVerbose("[PoisonInteraction:Perform] Evaluating player-supplied poison application.");
+            DebugLogSystem.LogVerbose("Evaluating player-supplied poison application.");
             if (playerProvidesPoison && applianceHasEligibleItem)
             {
                 EntityManager.AddComponent<CPoisoned>(applianceHeldItem.HeldItem);
-                DebugLogSystem.LogVerbose("[PoisonInteraction:Perform] Player bottle poisoned the appliance-held item.");
-                DebugLogSystem.LogVerbose("[PoisonInteraction:Perform] Poison status applied to the appliance-held item.");
+                DebugLogSystem.LogVerbose("Player bottle poisoned the appliance-held item.");
+                DebugLogSystem.LogVerbose("Poison status applied to the appliance-held item.");
                 poisonApplied = true;
             }
 
             // Apply poison when the appliance donates a bottle to contaminate the player-held item.
-            DebugLogSystem.LogVerbose("[PoisonInteraction:Perform] Evaluating appliance-supplied poison application.");
+            DebugLogSystem.LogVerbose("Evaluating appliance-supplied poison application.");
             if (!poisonApplied && applianceProvidesPoison && playerHasEligibleItem)
             {
                 EntityManager.AddComponent<CPoisoned>(playerHeldItem.HeldItem);
-                DebugLogSystem.LogVerbose("[PoisonInteraction:Perform] Appliance bottle poisoned the player-held item.");
-                DebugLogSystem.LogVerbose("[PoisonInteraction:Perform] Poison status applied to the player-held item.");
+                DebugLogSystem.LogVerbose("Appliance bottle poisoned the player-held item.");
+                DebugLogSystem.LogVerbose("Poison status applied to the player-held item.");
                 poisonApplied = true;
             }
 

--- a/Systems/ReplaceEmptySpecialSauce.cs
+++ b/Systems/ReplaceEmptySpecialSauce.cs
@@ -1,20 +1,22 @@
 ﻿using Kitchen;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using Unity.Collections;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems
 {
+    /// <summary>
+    /// Restores empty special sauce bottles to their configured replacement items so tables remain stocked.
+    /// </summary>
     public class ReplaceEmptySpecialSauce : GenericSystemBase, IModSystem
     {
         EntityQuery Items;
 
+        /// <summary>
+        /// Builds the query used to locate limited-use bottles that may require replacement.
+        /// </summary>
         protected override void Initialise()
         {
             base.Initialise();
@@ -22,16 +24,36 @@ namespace KitchenMysteryMeat.Systems
             Items = GetEntityQuery(typeof(CItem), typeof(CLimitedUseBottle));
 
         }
+
+        /// <summary>
+        /// Swaps empty sauce bottles for their configured replacements while reporting any unusual fill states.
+        /// </summary>
         protected override void OnUpdate()
         {
             using NativeArray<Entity> _items = Items.ToEntityArray(Allocator.Temp);
+
+            // Guard: exit early when no bottles require evaluation this frame.
+            if (_items.Length == 0)
+            {
+                return;
+            }
 
             foreach (Entity item in _items)
             {
                 CLimitedUseBottle cLimitedUseBottle = GetComponent<CLimitedUseBottle>(item);
 
+                // Guard: emit a warning when the fill amount dips below zero, indicating unexpected underflow.
+                if (cLimitedUseBottle.FillAmount < 0)
+                {
+                    DebugLogSystem.LogWarning("Detected a negative FillAmount on a sauce bottle; resetting to zero before replacement.");
+                    cLimitedUseBottle.FillAmount = 0;
+                    EntityManager.SetComponentData(item, cLimitedUseBottle);
+                }
+
+                // Guard: skip replacement when the bottle still contains charges.
                 if (cLimitedUseBottle.FillAmount <= 0)
                 {
+                    DebugLogSystem.LogVerbose($"Converting bottle entity {item.Index} to empty ID {cLimitedUseBottle.EmptyBottleID}.");
                     EntityManager.AddComponentData<CChangeItemType>(item, new CChangeItemType()
                     {
                         NewID = cLimitedUseBottle.EmptyBottleID,

--- a/Systems/TurnItemsIntoOthers.cs
+++ b/Systems/TurnItemsIntoOthers.cs
@@ -3,20 +3,22 @@ using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using Unity.Collections;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Systems
 {
+    /// <summary>
+    /// Converts tagged items into their configured replacements once the required data is present.
+    /// </summary>
     public class TurnItemsIntoOthers : GenericSystemBase, IModSystem
     {
         EntityQuery Items;
 
+        /// <summary>
+        /// Builds the query that locates items awaiting transformation.
+        /// </summary>
         protected override void Initialise()
         {
             base.Initialise();
@@ -24,16 +26,28 @@ namespace KitchenMysteryMeat.Systems
             Items = GetEntityQuery(typeof(CItem), typeof(CTurnIntoItem));
 
         }
+
+        /// <summary>
+        /// Applies transformation requests by swapping item types and clearing the marker component.
+        /// </summary>
         protected override void OnUpdate()
         {
             using NativeArray<Entity> _items = Items.ToEntityArray(Allocator.Temp);
+
+            // Guard: exit early when no items require transformation this frame.
+            if (_items.Length == 0)
+            {
+                return;
+            }
 
             foreach (Entity item in _items)
             {
                 CTurnIntoItem cTurnIntoItem = GetComponent<CTurnIntoItem>(item);
 
+                // Guard: skip when the transformation target has not been configured.
                 if (cTurnIntoItem.NewID == 0)
                 {
+                    DebugLogSystem.LogWarning($"Found item {item.Index} with an unset NewID; transformation skipped.");
                     continue;
                 }
                 EntityManager.AddComponentData<CChangeItemType>(item, new CChangeItemType()
@@ -41,6 +55,7 @@ namespace KitchenMysteryMeat.Systems
                     NewID = cTurnIntoItem.NewID,
                 });
                 EntityManager.RemoveComponent<CTurnIntoItem>(item);
+                DebugLogSystem.LogVerbose($"Changed item {item.Index} to new item ID {cTurnIntoItem.NewID}.");
             }
         }
     }

--- a/Views/LimitedUseBottleView.cs
+++ b/Views/LimitedUseBottleView.cs
@@ -1,6 +1,7 @@
 ﻿using Kitchen;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
+using KitchenMysteryMeat.Systems.Logging;
 using MessagePack;
 using System;
 using System.Collections.Generic;
@@ -13,21 +14,39 @@ using UnityEngine;
 
 namespace KitchenMysteryMeat.Views
 {
+    /// <summary>
+    /// Drives the limited-use bottle mesh materials to reflect remaining charges.
+    /// </summary>
     public class LimitedUseBottleView : UpdatableObjectView<LimitedUseBottleView.ViewData>
     {
         public GameObject Mesh;
         public Material BottleMaterial;
         public Material LiquidMaterial;
 
+        /// <summary>
+        /// Resolves the mesh used for material swapping when the view awakens.
+        /// </summary>
         private void Awake()
         {
             Mesh = transform.Find("LimitedUseBottle").gameObject;
         }
 
+        /// <summary>
+        /// Updates the bottle materials to reflect the supplied fill amount.
+        /// </summary>
         protected override void UpdateData(LimitedUseBottleView.ViewData data)
         {
-            if (!Mesh || !BottleMaterial || !LiquidMaterial || data.Equals(default(ViewData)))
+            if (!Mesh || !BottleMaterial || !LiquidMaterial)
+            {
+                DebugLogSystem.LogWarning("Limited-use bottle view is missing mesh or material references and cannot update visuals.");
                 return;
+            }
+
+            if (data.Equals(default(ViewData)))
+            {
+                DebugLogSystem.LogVerbose("Received default view data; skipping limited-use bottle update.");
+                return;
+            }
 
             MeshRenderer renderer = Mesh.GetComponent<MeshRenderer>();
             Material[] newMats = new Material[renderer.materials.Length];
@@ -43,15 +62,24 @@ namespace KitchenMysteryMeat.Views
             Mesh.GetComponent<MeshRenderer>().materials = newMats;
         }
 
+        /// <summary>
+        /// System responsible for keeping limited-use bottle visuals in sync with ECS data.
+        /// </summary>
         public class UpdateView : IncrementalViewSystemBase<ViewData>, IModSystem
         {
             private EntityQuery query;
+            /// <summary>
+            /// Builds the query that locates limited-use bottles with linked views.
+            /// </summary>
             protected override void Initialise()
             {
                 base.Initialise();
                 query = GetEntityQuery(new QueryHelper().All(typeof(CLinkedView), typeof(CLimitedUseBottle)));
             }
 
+            /// <summary>
+            /// Sends fill amount and limit information to each bottle view.
+            /// </summary>
             protected override void OnUpdate()
             {
                 using var views = query.ToComponentDataArray<CLinkedView>(Allocator.Temp);
@@ -67,6 +95,7 @@ namespace KitchenMysteryMeat.Views
                         Limit = limitedUseBottle.Limit,
                         FillAmount = limitedUseBottle.FillAmount
                     }, MessageType.SpecificViewUpdate);
+                    DebugLogSystem.LogVerbose($"Queued fill amount {limitedUseBottle.FillAmount}/{limitedUseBottle.Limit} for limited-use bottle view entity {view.Entity.Index}.");
                 }
             }
         }

--- a/Views/MeatGrinderView.cs
+++ b/Views/MeatGrinderView.cs
@@ -13,21 +13,37 @@ using Unity.Entities;
 using UnityEngine;
 using UnityEngine.UI;
 using Kitchen.Components;
+using KitchenMysteryMeat.Systems.Logging;
 
 
 namespace KitchenMysteryMeat.Views
 {
+    /// <summary>
+    /// Animates the grinder hold point to mirror grindable input presence and process progress.
+    /// </summary>
     public class MeatGrinderView : UpdatableObjectView<MeatGrinderView.ViewData>
     {
         public GameObject HoldPoint;
 
+        /// <summary>
+        /// Resolves the hold point transform used for visual adjustments.
+        /// </summary>
         private void Awake()
         {
             HoldPoint = transform.Find("GameObject").gameObject;
         }
 
+        /// <summary>
+        /// Updates the hold point location and scale according to the supplied view data.
+        /// </summary>
         protected override void UpdateData(MeatGrinderView.ViewData data)
         {
+            if (HoldPoint == null)
+            {
+                DebugLogSystem.LogWarning("Meat grinder view missing hold point transform; skipping update.");
+                return;
+            }
+
             if (data.HasGrindableItem)
             {
                 HoldPoint.transform.localPosition = data.GrinderInputPosition;
@@ -40,15 +56,24 @@ namespace KitchenMysteryMeat.Views
             HoldPoint.transform.localScale = new Vector3(inverseProgress, inverseProgress, inverseProgress);
         }
 
+        /// <summary>
+        /// System responsible for driving meat grinder view updates based on ECS state.
+        /// </summary>
         public class UpdateView : IncrementalViewSystemBase<ViewData>, IModSystem
         {
             private EntityQuery query;
+            /// <summary>
+            /// Builds the query that locates meat grinders with linked views and process data.
+            /// </summary>
             protected override void Initialise()
             {
                 base.Initialise();
                 query = GetEntityQuery(new QueryHelper().All(typeof(CLinkedView), typeof(CMeatGrinder), typeof(CApplyingProcess), typeof(CItemHolder)));
             }
 
+            /// <summary>
+            /// Sends grinder state updates to the associated views.
+            /// </summary>
             protected override void OnUpdate()
             {
                 using var views = query.ToComponentDataArray<CLinkedView>(Allocator.Temp);
@@ -70,6 +95,7 @@ namespace KitchenMysteryMeat.Views
                         GrinderInputPosition = meatGrinder.GrinderInputPosition,
                         GrinderOutputPosition = meatGrinder.GrinderOutputPosition,
                     }, MessageType.SpecificViewUpdate);
+                    DebugLogSystem.LogVerbose($"Queued progress {applyingProcess.Progress:P0} for grinder entity {view.Entity.Index}.");
                 }
             }
         }

--- a/Views/SuspicionIndicatorView.cs
+++ b/Views/SuspicionIndicatorView.cs
@@ -12,6 +12,9 @@ using UnityEngine.UI;
 
 namespace KitchenMysteryMeat.Views
 {
+    /// <summary>
+    /// Presents suspicion and alert indicators above customers based on linked ECS data and preferences.
+    /// </summary>
     public class SuspicionIndicatorView : UpdatableObjectView<SuspicionIndicatorView.ViewData>
     {
         public GameObject Canvas;
@@ -54,7 +57,7 @@ namespace KitchenMysteryMeat.Views
             {
                 if (!_missingPreferenceWarningLogged)
                 {
-                    DebugLogSystem.LogVerbose("Mystery Meat deferred suspicion indicator preference lookups because preferences are not initialised.");
+                    DebugLogSystem.LogVerbose("Deferred suspicion indicator preference lookups because preferences are not initialised.");
                     _missingPreferenceWarningLogged = true;
                 }
             }
@@ -169,6 +172,9 @@ namespace KitchenMysteryMeat.Views
             transform.rotation = Quaternion.identity;
         }
 
+        /// <summary>
+        /// Drives suspicion indicator view updates from ECS component changes.
+        /// </summary>
         public class UpdateView : IncrementalViewSystemBase<ViewData>, IModSystem
         {
             private EntityQuery query;

--- a/Views/TrashBagView.cs
+++ b/Views/TrashBagView.cs
@@ -1,6 +1,7 @@
 ﻿using Kitchen;
 using KitchenMods;
 using KitchenMysteryMeat.Components;
+using KitchenMysteryMeat.Systems.Logging;
 using MessagePack;
 using System;
 using System.Collections.Generic;
@@ -13,10 +14,17 @@ using UnityEngine;
 
 namespace KitchenMysteryMeat.Views
 {
+    /// <summary>
+    /// Synchronises the trash bag visuals with stored corpse data to represent remaining portions.
+    /// </summary>
     public class TrashBagView : UpdatableObjectView<TrashBagView.ViewData>
     {
         public Transform TrashBag;
         public Transform CorpsesParent;
+
+        /// <summary>
+        /// Captures transform references for the trash bag visuals and corpse container.
+        /// </summary>
         private void Awake()
         {
             TrashBag = transform.Find("Trash Bag");
@@ -25,11 +33,21 @@ namespace KitchenMysteryMeat.Views
             CorpsesParent.gameObject.SetActive(false);
         }
 
+        /// <summary>
+        /// Toggles corpse meshes based on the supplied view data and tracks invalid state for debugging.
+        /// </summary>
         protected override void UpdateData(TrashBagView.ViewData data)
         {
+            // Guard: ensure required transforms are available before applying updates.
+            if (TrashBag == null || CorpsesParent == null)
+            {
+                DebugLogSystem.LogWarning("Trash bag view attempted to update without configured transforms.");
+                return;
+            }
+
             TrashBag.gameObject.SetActive(!data.ContainsCorpse);
             CorpsesParent.gameObject.SetActive(data.ContainsCorpse);
-            
+
             if (data.ContainsCorpse)
             {
                 for (int i = 0; i < CorpsesParent.childCount; i++)
@@ -41,15 +59,24 @@ namespace KitchenMysteryMeat.Views
             }
         }
 
+        /// <summary>
+        /// System responsible for pushing trash bag view updates from ECS data.
+        /// </summary>
         public class UpdateView : IncrementalViewSystemBase<ViewData>, IModSystem
         {
             private EntityQuery query;
+            /// <summary>
+            /// Builds the query that locates trash bags with linked views and stored items.
+            /// </summary>
             protected override void Initialise()
             {
                 base.Initialise();
                 query = GetEntityQuery(new QueryHelper().All(typeof(CLinkedView), typeof(CTrashBag), typeof(CItemStored)));
             }
 
+            /// <summary>
+            /// Pushes updated corpse counts to the linked trash bag views.
+            /// </summary>
             protected override void OnUpdate()
             {
                 using var entities = query.ToEntityArray(Allocator.Temp);
@@ -68,13 +95,18 @@ namespace KitchenMysteryMeat.Views
                             TotalPortions = cSplittableItem.TotalCount,
                             RemainingPortions = cSplittableItem.RemainingCount,
                         }, MessageType.SpecificViewUpdate);
-                    }   
+                        DebugLogSystem.LogVerbose($"Pushed corpse counts {cSplittableItem.RemainingCount}/{cSplittableItem.TotalCount} for trash bag entity {entities[i].Index}.");
+                    }
                     else
                     {
                         SendUpdate(view, new ViewData
                         {
                             ContainsCorpse = false,
                         }, MessageType.SpecificViewUpdate);
+                        if (itemStored.Length == 0)
+                        {
+                            DebugLogSystem.LogVerbose($"Cleared corpse visuals because trash bag {entities[i].Index} has no stored items.");
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- update DebugLogSystem to automatically prepend file-scoped prefixes and keep stack-trace support for warnings, errors, and verbose logs
- clean up manual prefixes while extending diagnostics and comments across gameplay systems and helper utilities
- refresh bottle, trash bag, and suspicion indicator views with descriptive logging free of redundant prefixes
- document the remaining files that still require summary comments or debug coverage as of Sept 24, 2025 @ 3:30 a.m. CST

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a1da2e80832ebbfcfd99d117f160