### PR TITLE
Document gameplay components and integrate debug logging

### DIFF
--- a/Components/CEmptyBottle.cs
+++ b/Components/CEmptyBottle.cs
@@ -1,10 +1,16 @@
-﻿using KitchenMods;
 using KitchenData;
+using KitchenMods;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Tags an empty special sauce bottle so refill systems can restore it to the configured full variant.
+    /// </summary>
     public struct CEmptyBottle : IModComponent, IItemProperty, IAttachableProperty
     {
+        /// <summary>
+        /// Identifies the item definition for the refilled bottle that should replace this empty container.
+        /// </summary>
         public int FullBottleID;
     }
 }

--- a/Components/CFillsBottle.cs
+++ b/Components/CFillsBottle.cs
@@ -1,15 +1,16 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Marks appliances that can refill empty bottles with the specified filled bottle item.
+    /// </summary>
     public struct CFillsBottle : IModComponent, IApplianceProperty, IAttachableProperty
     {
+        /// <summary>
+        /// Identifies the bottle item that is dispensed after a successful refill interaction.
+        /// </summary>
         public int BottleID;
     }
 }

--- a/Components/CGrindable.cs
+++ b/Components/CGrindable.cs
@@ -1,13 +1,11 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Identifies items that should be processed by grinder appliances or processes.
+    /// </summary>
     public struct CGrindable : IModComponent, IAttachableProperty, IItemProperty
     {
     }

--- a/Components/CIllegalSight.cs
+++ b/Components/CIllegalSight.cs
@@ -1,16 +1,16 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Flags items or appliances that count as illegal sightings and optionally convert into another object at day start.
+    /// </summary>
     public struct CIllegalSight : IModComponent, IAttachableProperty, IItemProperty, IApplianceProperty
     {
-        //public bool PersistBetweenDays;
+        /// <summary>
+        /// Stores the game data ID that this entity should transform into when a new day begins.
+        /// </summary>
         public int TurnIntoOnDayStart;
     }
 }

--- a/Components/CIllegalSightHolderPreserved.cs
+++ b/Components/CIllegalSightHolderPreserved.cs
@@ -2,8 +2,14 @@ using KitchenMods;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Maintains a flag that notes when an illegal sight holder gained a preservation component for the next day.
+    /// </summary>
     public struct CIllegalSightHolderPreserved : IModComponent
     {
+        /// <summary>
+        /// Indicates whether the preservation component has already been attached to prevent duplicate work.
+        /// </summary>
         public bool AddedPreserver;
     }
 }

--- a/Components/CKilled.cs
+++ b/Components/CKilled.cs
@@ -1,15 +1,15 @@
-﻿using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Tracks whether a customer has been killed and whether the resulting mess should be treated as bloody.
+    /// </summary>
     public struct CKilled : IModComponent
     {
+        /// <summary>
+        /// Records whether the eliminated customer produced a bloodied body for later cleanup routines.
+        /// </summary>
         public bool Bloody;
     }
 }

--- a/Components/CKillsCustomer.cs
+++ b/Components/CKillsCustomer.cs
@@ -1,14 +1,11 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Unity.Entities;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Tags tools and items that can directly kill customers when used by the player.
+    /// </summary>
     public struct CKillsCustomer : IModComponent, IItemProperty, IAttachableProperty
     {
     }

--- a/Components/CLimitedUseBottle.cs
+++ b/Components/CLimitedUseBottle.cs
@@ -1,19 +1,32 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Tracks refill charges for bottles that can only dispense a limited number of servings before running dry.
+    /// </summary>
     public struct CLimitedUseBottle : IModComponent, IItemProperty, IAttachableProperty
     {
+        /// <summary>
+        /// Defines how many servings the bottle can provide before it must be refilled.
+        /// </summary>
         public int Limit;
+
+        /// <summary>
+        /// Stores the remaining number of servings currently available from the bottle.
+        /// </summary>
         public int FillAmount;
+
+        /// <summary>
+        /// Remembers the last customer who interacted with the bottle so suspicion logic can react accordingly.
+        /// </summary>
         public Entity LastUsedByCustomer;
+
+        /// <summary>
+        /// Provides the item ID to spawn when the bottle has been depleted and should be replaced with an empty container.
+        /// </summary>
         public int EmptyBottleID;
     }
 }

--- a/Components/CMeatGrinder.cs
+++ b/Components/CMeatGrinder.cs
@@ -1,18 +1,27 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Exposes the offsets and process ID required for appliances that animate and output ground meat.
+    /// </summary>
     public struct CMeatGrinder : IModComponent, IAttachableProperty, IApplianceProperty
     {
+        /// <summary>
+        /// Captures the world-space position where ingredients enter the grinder.
+        /// </summary>
         public Vector3 GrinderInputPosition;
+
+        /// <summary>
+        /// Captures the world-space position where processed meat exits the grinder.
+        /// </summary>
         public Vector3 GrinderOutputPosition;
+
+        /// <summary>
+        /// Links to the grind process that should be triggered when items enter the appliance.
+        /// </summary>
         public int GrindProcess;
     }
 }

--- a/Components/CPersistPortions.cs
+++ b/Components/CPersistPortions.cs
@@ -1,16 +1,21 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Keeps track of consumable portion counts that should persist between days.
+    /// </summary>
     public struct CPersistPortions : IModComponent, IItemProperty, IAttachableProperty
     {
+        /// <summary>
+        /// Indicates how many servings remain available after the latest use.
+        /// </summary>
         public int RemainingCount;
+
+        /// <summary>
+        /// Stores the total number of servings the item contained at the start of the day for reset logic.
+        /// </summary>
         public int TotalCount;
     }
 }

--- a/Components/CPoisonBottle.cs
+++ b/Components/CPoisonBottle.cs
@@ -1,13 +1,11 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Identifies bottles that contain poison so interaction systems can apply lethal effects.
+    /// </summary>
     public struct CPoisonBottle : IModComponent, IItemProperty, IAttachableProperty
     {
     }

--- a/Components/CPoisoned.cs
+++ b/Components/CPoisoned.cs
@@ -1,13 +1,11 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Marks entities that have been poisoned so downstream systems can handle delayed kills or reactions.
+    /// </summary>
     public struct CPoisoned : IModComponent, IItemProperty, IAttachableProperty
     {
     }

--- a/Components/CProcessCausesSpill.cs
+++ b/Components/CProcessCausesSpill.cs
@@ -1,21 +1,31 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Describes spill behaviour that is triggered when a specific process runs on an item or appliance.
+    /// </summary>
     public struct CProcessCausesSpill : IModComponent, IItemProperty, IAttachableProperty
     {
+        /// <summary>
+        /// Identifies the process that should emit spill messes when executed.
+        /// </summary>
         public int Process;
-        // ID of Spill
+
+        /// <summary>
+        /// Points to the mess ID that should be spawned as part of the spill.
+        /// </summary>
         public int ID;
-        // Rate of Spilling
+
+        /// <summary>
+        /// Indicates how quickly the spill should accumulate while the process runs.
+        /// </summary>
         public float Rate;
-        // Will this replace other messes
+
+        /// <summary>
+        /// Determines whether the generated mess should overwrite existing messes at the location.
+        /// </summary>
         public bool OverwriteOtherMesses;
     }
 }

--- a/Components/CSuspicionIndicator.cs
+++ b/Components/CSuspicionIndicator.cs
@@ -1,19 +1,32 @@
-﻿using KitchenMods;
+using KitchenMods;
 using KitchenMysteryMeat.Enums;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Unity.Entities;
 
 namespace KitchenMysteryMeat.Components
 {
-    public struct CSuspicionIndicator: IModComponent
+    /// <summary>
+    /// Tracks suspicion UI state for customers who witnessed illegal activity.
+    /// </summary>
+    public struct CSuspicionIndicator : IModComponent
     {
+        /// <summary>
+        /// Indicates the visual indicator style that should be shown to the player.
+        /// </summary>
         public SuspicionIndicatorType IndicatorType;
+
+        /// <summary>
+        /// References the illegal entity the customer saw so follow-up systems can resolve it.
+        /// </summary>
         public Entity? SeenIllegalThing;
+
+        /// <summary>
+        /// Stores the total duration that the suspicion indicator should remain active.
+        /// </summary>
         public float TotalTime;
+
+        /// <summary>
+        /// Captures the remaining time before the suspicion indicator expires.
+        /// </summary>
         public float RemainingTime;
     }
 }

--- a/Components/CTrashBag.cs
+++ b/Components/CTrashBag.cs
@@ -1,13 +1,11 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Marks trash bags so systems can enforce special carrying rules and disposal logic.
+    /// </summary>
     public struct CTrashBag : IModComponent, IItemProperty, IAttachableProperty
     {
     }

--- a/Components/CTurnIntoItem.cs
+++ b/Components/CTurnIntoItem.cs
@@ -1,15 +1,16 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenMods;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace KitchenMysteryMeat.Components
 {
+    /// <summary>
+    /// Directs systems to replace an item with another item definition when specific triggers fire.
+    /// </summary>
     public struct CTurnIntoItem : IModComponent, IItemProperty, IAttachableProperty
     {
+        /// <summary>
+        /// Stores the ID for the item that should replace the current entity once the conversion happens.
+        /// </summary>
         public int NewID;
     }
 }

--- a/Customs/Appliances/BloodSpill1.cs
+++ b/Customs/Appliances/BloodSpill1.cs
@@ -1,19 +1,19 @@
-﻿using Kitchen;
+using System.Collections.Generic;
+using Kitchen;
 using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Items;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Appliances
 {
+    /// <summary>
+    /// Represents the initial blood spill mess that slows players and enables special sauce bottle refills.
+    /// </summary>
     public class BloodSpill1 : CustomAppliance
     {
         public override string UniqueNameID => "BloodSpill1";
@@ -22,14 +22,14 @@ namespace KitchenMysteryMeat.Customs.Appliances
         public override EntryAnimation EntryAnimation => EntryAnimation.Mess;
         public override ExitAnimation ExitAnimation => ExitAnimation.MessDestroy;
 
-        public override List<IApplianceProperty> Properties => new List<IApplianceProperty>()
+        public override List<IApplianceProperty> Properties => new List<IApplianceProperty>
         {
-            new CSlowPlayer()
+            new CSlowPlayer
             {
                 Radius = 0.2f,
                 Factor = 1.1f
             },
-            new CTakesDuration()
+            new CTakesDuration
             {
                 Total = 1,
                 Manual = true,
@@ -39,22 +39,37 @@ namespace KitchenMysteryMeat.Customs.Appliances
             },
             new CDestroyAfterDuration(),
             new CDestroyApplianceAtNight(),
-            new CDisplayDuration()
+            new CDisplayDuration
             {
                 IsBad = false,
                 Process = ProcessReferences.Clean,
                 ShowWhenEmpty = false
             },
-            new CStackableMess()
+            new CStackableMess
             {
                 BaseMess = ID,
                 NextMess = GDOUtils.GetCustomGameDataObject<BloodSpill2>().ID
             },
             new CIllegalSight(),
-            new CFillsBottle()
+            new CFillsBottle
             {
                 BottleID = GDOUtils.GetCustomGameDataObject<SpecialSauceBottle>().ID
             }
         };
+
+        /// <summary>
+        /// Emits verbose diagnostics describing the refill routing for the first blood spill tier.
+        /// </summary>
+        /// <param name="gameDataObject">The appliance definition being registered.</param>
+        public override void OnRegister(Appliance gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int refillBottleId = GDOUtils.GetCustomGameDataObject<SpecialSauceBottle>().ID;
+            int escalationTargetId = GDOUtils.GetCustomGameDataObject<BloodSpill2>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"BloodSpill1 registered with refill bottle ID {refillBottleId} and escalation target {escalationTargetId}.");
+        }
     }
 }

--- a/Customs/Appliances/BloodSpill2.cs
+++ b/Customs/Appliances/BloodSpill2.cs
@@ -1,19 +1,19 @@
-﻿using Kitchen;
+using System.Collections.Generic;
+using Kitchen;
 using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Items;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Appliances
 {
+    /// <summary>
+    /// Represents the mid-stage blood spill that deepens slowing effects and advances to the final mess tier.
+    /// </summary>
     public class BloodSpill2 : CustomAppliance
     {
         public override string UniqueNameID => "BloodSpill2";
@@ -22,14 +22,14 @@ namespace KitchenMysteryMeat.Customs.Appliances
         public override EntryAnimation EntryAnimation => EntryAnimation.Mess;
         public override ExitAnimation ExitAnimation => ExitAnimation.MessDestroy;
 
-        public override List<IApplianceProperty> Properties => new List<IApplianceProperty>()
+        public override List<IApplianceProperty> Properties => new List<IApplianceProperty>
         {
-            new CSlowPlayer()
+            new CSlowPlayer
             {
                 Radius = 0.25f,
                 Factor = 1.0f
             },
-            new CTakesDuration()
+            new CTakesDuration
             {
                 Total = 3,
                 Manual = true,
@@ -39,22 +39,38 @@ namespace KitchenMysteryMeat.Customs.Appliances
             },
             new CDestroyAfterDuration(),
             new CDestroyApplianceAtNight(),
-            new CDisplayDuration()
+            new CDisplayDuration
             {
                 IsBad = false,
                 Process = ProcessReferences.Clean,
                 ShowWhenEmpty = false
             },
-            new CStackableMess()
+            new CStackableMess
             {
                 BaseMess = GDOUtils.GetCustomGameDataObject<BloodSpill1>().ID,
                 NextMess = GDOUtils.GetCustomGameDataObject<BloodSpill3>().ID
             },
             new CIllegalSight(),
-            new CFillsBottle()
+            new CFillsBottle
             {
                 BottleID = GDOUtils.GetCustomGameDataObject<SpecialSauceBottle>().ID
             }
         };
+
+        /// <summary>
+        /// Emits verbose diagnostics about the escalation path and refill behaviour for the second blood spill tier.
+        /// </summary>
+        /// <param name="gameDataObject">The appliance definition being registered.</param>
+        public override void OnRegister(Appliance gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int previousMessId = GDOUtils.GetCustomGameDataObject<BloodSpill1>().ID;
+            int nextMessId = GDOUtils.GetCustomGameDataObject<BloodSpill3>().ID;
+            int refillBottleId = GDOUtils.GetCustomGameDataObject<SpecialSauceBottle>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"BloodSpill2 registered with previous mess {previousMessId}, next mess {nextMessId}, and refill bottle ID {refillBottleId}.");
+        }
     }
 }

--- a/Customs/Appliances/BloodSpill3.cs
+++ b/Customs/Appliances/BloodSpill3.cs
@@ -1,19 +1,19 @@
-﻿using Kitchen;
+using System.Collections.Generic;
+using Kitchen;
 using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Items;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Appliances
 {
+    /// <summary>
+    /// Represents the final blood spill escalation that demands the longest cleanup time and still refills bottles.
+    /// </summary>
     public class BloodSpill3 : CustomAppliance
     {
         public override string UniqueNameID => "BloodSpill3";
@@ -22,14 +22,14 @@ namespace KitchenMysteryMeat.Customs.Appliances
         public override EntryAnimation EntryAnimation => EntryAnimation.Mess;
         public override ExitAnimation ExitAnimation => ExitAnimation.MessDestroy;
 
-        public override List<IApplianceProperty> Properties => new List<IApplianceProperty>()
+        public override List<IApplianceProperty> Properties => new List<IApplianceProperty>
         {
-            new CSlowPlayer()
+            new CSlowPlayer
             {
                 Radius = 0.3f,
                 Factor = 0.9f
             },
-            new CTakesDuration()
+            new CTakesDuration
             {
                 Total = 6,
                 Manual = true,
@@ -39,17 +39,31 @@ namespace KitchenMysteryMeat.Customs.Appliances
             },
             new CDestroyAfterDuration(),
             new CDestroyApplianceAtNight(),
-            new CDisplayDuration()
+            new CDisplayDuration
             {
                 IsBad = false,
                 Process = ProcessReferences.Clean,
                 ShowWhenEmpty = false
             },
             new CIllegalSight(),
-            new CFillsBottle()
+            new CFillsBottle
             {
                 BottleID = GDOUtils.GetCustomGameDataObject<SpecialSauceBottle>().ID
             }
         };
+
+        /// <summary>
+        /// Logs the clean-up burden for the final spill tier while confirming refill support.
+        /// </summary>
+        /// <param name="gameDataObject">The appliance definition being registered.</param>
+        public override void OnRegister(Appliance gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int refillBottleId = GDOUtils.GetCustomGameDataObject<SpecialSauceBottle>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"BloodSpill3 registered as the terminal tier with refill bottle ID {refillBottleId} and a 6 second clean time.");
+        }
     }
 }

--- a/Customs/Appliances/CasingsProvider.cs
+++ b/Customs/Appliances/CasingsProvider.cs
@@ -1,16 +1,16 @@
-﻿using KitchenData;
+using System.Collections.Generic;
+using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Customs.Items;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Appliances
 {
+    /// <summary>
+    /// Provides an unlimited supply of hotdog casings once the restaurant owns a meat cleaver provider.
+    /// </summary>
     public class CasingsProvider : CustomAppliance
     {
         public override string UniqueNameID => "CasingsProvider";
@@ -23,8 +23,9 @@ namespace KitchenMysteryMeat.Customs.Appliances
 
         public override List<(Locale, ApplianceInfo)> InfoList => new()
         {
-            ( Locale.English, LocalisationUtils.CreateApplianceInfo("Casings", "Provides hotdog casings", new(), new()) )
+            (Locale.English, LocalisationUtils.CreateApplianceInfo("Casings", "Provides hotdog casings", new(), new()))
         };
+
         public override List<IApplianceProperty> Properties => new()
         {
             KitchenPropertiesUtils.GetUnlimitedCItemProvider(GDOUtils.GetCustomGameDataObject<Casing>().ID)
@@ -34,5 +35,20 @@ namespace KitchenMysteryMeat.Customs.Appliances
         {
             (Appliance)GDOUtils.GetCustomGameDataObject<MeatCleaverProvider>().GameDataObject
         };
+
+        /// <summary>
+        /// Reports the provider requirements and unlimited stock configuration during registration.
+        /// </summary>
+        /// <param name="gameDataObject">The appliance definition being registered.</param>
+        public override void OnRegister(Appliance gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int casingId = GDOUtils.GetCustomGameDataObject<Casing>().ID;
+            int prerequisiteApplianceId = GDOUtils.GetCustomGameDataObject<MeatCleaverProvider>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"CasingsProvider registered unlimited casing supply (item {casingId}) with prerequisite appliance {prerequisiteApplianceId}.");
+        }
     }
 }

--- a/Customs/Appliances/CustomerFloorCorpse.cs
+++ b/Customs/Appliances/CustomerFloorCorpse.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Kitchen;
 using KitchenData;
 using KitchenLib.Customs;
@@ -5,40 +6,43 @@ using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Items;
-using System.Collections.Generic;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Appliances
 {
+    /// <summary>
+    /// Spawns a fresh corpse that can be harvested once before decaying into a rotten variant overnight.
+    /// </summary>
     public class CustomerFloorCorpse : CustomAppliance
     {
         public override string UniqueNameID => "CustomerFloorCorpse";
         public override GameObject Prefab => Mod.Bundle.LoadAsset<GameObject>("Customer Floor Corpse").AssignMaterialsByNames();
         public override OccupancyLayer Layer => OccupancyLayer.Floor;
 
-        public override List<IApplianceProperty> Properties => new List<IApplianceProperty>()
+        public override List<IApplianceProperty> Properties => new List<IApplianceProperty>
         {
-            //new CDestroyApplianceAtNight(),
             KitchenPropertiesUtils.GetCItemProvider(GDOUtils.GetCustomGameDataObject<CustomerCorpse>().ID, 1, 1, false, false, false, true, false, false, false),
-            new CIllegalSight()
+            new CIllegalSight
             {
                 TurnIntoOnDayStart = GDOUtils.GetCustomGameDataObject<RottenCustomerFloorCorpse>().ID
             },
-            new CImmovable(),
-/*
-            new CTakesDuration()
-            {
-                Total = 0.5f,
-                Active = false,
-                Manual = false,
-                
-            },
-            new CCausesSpills()
-            {
-                ID = GDOUtils.GetCustomGameDataObject<BloodSpill1>().ID,
-                Rate = 2f,
-                OverwriteOtherMesses = false
-            }*/
+            new CImmovable()
         };
+
+        /// <summary>
+        /// Reports the overnight decay target and provided corpse stock when the appliance registers.
+        /// </summary>
+        /// <param name="gameDataObject">The appliance definition being registered.</param>
+        public override void OnRegister(Appliance gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int freshCorpseId = GDOUtils.GetCustomGameDataObject<CustomerCorpse>().ID;
+            int rottenCorpseApplianceId = GDOUtils.GetCustomGameDataObject<RottenCustomerFloorCorpse>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"CustomerFloorCorpse registered with provider item {freshCorpseId} and overnight conversion target {rottenCorpseApplianceId}.");
+        }
     }
 }

--- a/Customs/Appliances/RottenCustomerFloorCorpse.cs
+++ b/Customs/Appliances/RottenCustomerFloorCorpse.cs
@@ -1,46 +1,43 @@
-﻿using Kitchen;
+using System.Collections.Generic;
+using Kitchen;
 using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Items;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Appliances
 {
+    /// <summary>
+    /// Represents the rotten corpse variant that remains after an uncleaned body decomposes overnight.
+    /// </summary>
     public class RottenCustomerFloorCorpse : CustomAppliance
     {
         public override string UniqueNameID => "RottenCustomerFloorCorpse";
         public override GameObject Prefab => Mod.Bundle.LoadAsset<GameObject>("Rotten Customer Floor Corpse").AssignMaterialsByNames().AssignVFXByNames();
         public override OccupancyLayer Layer => OccupancyLayer.Floor;
 
-        public override List<IApplianceProperty> Properties => new List<IApplianceProperty>()
+        public override List<IApplianceProperty> Properties => new List<IApplianceProperty>
         {
-            //new CDestroyApplianceAtNight(),
             KitchenPropertiesUtils.GetCItemProvider(GDOUtils.GetCustomGameDataObject<RottenCustomerCorpse>().ID, 1, 1, false, false, false, true, false, false, false),
-            new CIllegalSight()
-            {
-            },
-            new CImmovable(),
-/*
-            new CTakesDuration()
-            {
-                Total = 0.5f,
-                Active = false,
-                Manual = false,
-                
-            },
-            new CCausesSpills()
-            {
-                ID = GDOUtils.GetCustomGameDataObject<BloodSpill1>().ID,
-                Rate = 2f,
-                OverwriteOtherMesses = false
-            }*/
+            new CIllegalSight(),
+            new CImmovable()
         };
+
+        /// <summary>
+        /// Emits diagnostics confirming the rotten corpse provider stock during registration.
+        /// </summary>
+        /// <param name="gameDataObject">The appliance definition being registered.</param>
+        public override void OnRegister(Appliance gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int rottenCorpseItemId = GDOUtils.GetCustomGameDataObject<RottenCustomerCorpse>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"RottenCustomerFloorCorpse registered with provider item {rottenCorpseItemId} and immovable illegal sight status.");
+        }
     }
 }

--- a/Customs/Appliances/TrashBagProvider.cs
+++ b/Customs/Appliances/TrashBagProvider.cs
@@ -1,30 +1,31 @@
-﻿using KitchenData;
+using System.Collections.Generic;
+using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Customs.Items;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Appliances
 {
+    /// <summary>
+    /// Provides unlimited trash bags once the restaurant has invested in the meat cleaver provider.
+    /// </summary>
     public class TrashBagProvider : CustomAppliance
     {
         public override string UniqueNameID => "TrashBagProvider";
         public override GameObject Prefab => Mod.Bundle.LoadAsset<GameObject>("Trash Bag Provider").AssignMaterialsByNames().AssignVFXByNames();
         public override PriceTier PriceTier => PriceTier.VeryExpensive;
         public override RarityTier RarityTier => RarityTier.Uncommon;
-        public override bool SellOnlyAsDuplicate => true;//false;
+        public override bool SellOnlyAsDuplicate => true;
         public override bool IsPurchasable => true;
         public override ShoppingTags ShoppingTags => ShoppingTags.Misc;
 
         public override List<(Locale, ApplianceInfo)> InfoList => new()
         {
-            ( Locale.English, LocalisationUtils.CreateApplianceInfo("Trash Bags", "Large enough to fit some body!", new(), new()) )
+            (Locale.English, LocalisationUtils.CreateApplianceInfo("Trash Bags", "Large enough to fit some body!", new(), new()))
         };
+
         public override List<IApplianceProperty> Properties => new()
         {
             KitchenPropertiesUtils.GetUnlimitedCItemProvider(GDOUtils.GetCustomGameDataObject<TrashBag>().ID)
@@ -34,5 +35,20 @@ namespace KitchenMysteryMeat.Customs.Appliances
         {
             (Appliance)GDOUtils.GetCustomGameDataObject<MeatCleaverProvider>().GameDataObject
         };
+
+        /// <summary>
+        /// Emits verbose diagnostics about the trash bag stock and dependency requirements.
+        /// </summary>
+        /// <param name="gameDataObject">The appliance definition being registered.</param>
+        public override void OnRegister(Appliance gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int trashBagId = GDOUtils.GetCustomGameDataObject<TrashBag>().ID;
+            int prerequisiteApplianceId = GDOUtils.GetCustomGameDataObject<MeatCleaverProvider>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"TrashBagProvider registered unlimited trash bag supply (item {trashBagId}) with prerequisite appliance {prerequisiteApplianceId}.");
+        }
     }
 }

--- a/Customs/Dishes/MysteryMeatBurgerDish.cs
+++ b/Customs/Dishes/MysteryMeatBurgerDish.cs
@@ -5,68 +5,48 @@ using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Customs.Items;
 using KitchenMysteryMeat.Customs.Processes;
-
-
-//using KitchenMysteryMeat.Customs.ItemGroups;
-//using KitchenMysteryMeat.Customs.Items;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Dishes
 {
+    /// <summary>
+    /// Unlocks the core mystery meat burger offering that introduces corpse harvesting and grinder gameplay.
+    /// </summary>
     public class MysteryMeatBurgerDish : CustomDish
     {
         public override string UniqueNameID => "MysteryMeatBurgerDish";
-
-        // ExpReward - Determines how much XP this Unlock provides.
         public override Unlock.RewardLevel ExpReward => Unlock.RewardLevel.Medium;
-
-        // IsUnlockable - When TRUE this Unlock can appear in the card selector.
         public override bool IsUnlockable => true;
-
-        // UnlockGroup - Determines what type of Unlock this is.
         public override UnlockGroup UnlockGroup => UnlockGroup.Dish;
-
-        // CardType - Determines when this Unlock can be selected.
         public override CardType CardType => CardType.Default;
-
-        // CustomerMultiplier - Determines the customer difference this Unlock provides.
         public override DishCustomerChange CustomerMultiplier => DishCustomerChange.SmallDecrease;
-
-        // Type - This is used to decide what phase this Dish should be ordered.
         public override DishType Type => DishType.Base;
-
-        // Difficulty - This is displayed in the lobby. (0 - 5)
         public override int Difficulty => 3;
-
-        // StartingNameSet - The list of names used to decide the default Restaurant name.
-        public override List<string> StartingNameSet => new List<string>
+        public override List<string> StartingNameSet => new()
         {
             "We Won't Kill You",
             "Fresh Never Frozen"
         };
 
-        // MinimumIngredients - The ingredients required to make this Dish.
-        public override HashSet<Item> MinimumIngredients => new HashSet<Item>()
+        public override HashSet<Item> MinimumIngredients => new()
         {
             (Item)GDOUtils.GetCustomGameDataObject<MeatCleaver>().GameDataObject,
             (Item)GDOUtils.GetExistingGDO(ItemReferences.BurgerBun),
             (Item)GDOUtils.GetExistingGDO(ItemReferences.Water),
-            (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate)
         };
 
-        // RequiredProcesses - The processes required to make this Dish.
-        public override HashSet<Process> RequiredProcesses => new HashSet<Process>
+        public override HashSet<Process> RequiredProcesses => new()
         {
             (Process)GDOUtils.GetExistingGDO(ProcessReferences.Cook),
             GDOUtils.GetCastedGDO<Process, GrindMeat>()
         };
 
-        // IconPrefab - This is the Icon displayed in the lobby.
         public override GameObject IconPrefab => Mod.Bundle.LoadAsset<GameObject>("Mystery Meat - Icon").AssignMaterialsByNames();
         public override GameObject DisplayPrefab => (GDOUtils.GetExistingGDO(DishReferences.BurgerBase) as Dish).DisplayPrefab;
 
-        // ResultingMenuItems - What menu Items are available to customers after unlocking this Dish.
-        public override List<Dish.MenuItem> ResultingMenuItems => new List<Dish.MenuItem>
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
         {
             new Dish.MenuItem
             {
@@ -78,28 +58,25 @@ namespace KitchenMysteryMeat.Customs.Dishes
             }
         };
 
-        // IsAvailableAsLobbyOption - When TRUE this Dish will appear in the lobby.
         public override bool IsAvailableAsLobbyOption => true;
         public override HashSet<Item> BlockProviders => new()
         {
             (Item)GDOUtils.GetExistingGDO(ItemReferences.Meat),
-            (Item)GDOUtils.GetExistingGDO(ItemReferences.BurgerPattyRaw),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.BurgerPattyRaw)
         };
 
-        // Recipe - This is the recipe displayed when unlocking this Dish.
-        public override Dictionary<Locale, string> Recipe => new Dictionary<Locale, string>
+        public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English, "Put 'fresh meat' in meat grinder to get minced meat. Knead to form patty. Cook burger patty and add bun." }
         };
 
-        // InfoList - This is used to assign localisation to this Dish.
-        public override List<(Locale, UnlockInfo)> InfoList => new List<(Locale, UnlockInfo)>
+        public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo
             {
                 Name = "Mystery Meat Burgers",
                 Description = "Adds \"fresh meat\" burgers as a main",
-                FlavourText = ""
+                FlavourText = string.Empty
             })
         };
 
@@ -107,5 +84,19 @@ namespace KitchenMysteryMeat.Customs.Dishes
         {
             (Dish)GDOUtils.GetCustomGameDataObject<MysteryMeatDish>().GameDataObject
         };
+
+        /// <summary>
+        /// Emits verbose diagnostics capturing the grinder dependency when the dish is registered.
+        /// </summary>
+        /// <param name="gameDataObject">The dish definition being registered.</param>
+        public override void OnRegister(Dish gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int grindProcessId = GDOUtils.GetCustomGameDataObject<GrindMeat>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"MysteryMeatBurgerDish registered with grind process {grindProcessId} and blocked vanilla meat providers.");
+        }
     }
 }

--- a/Customs/Dishes/MysteryMeatHotdogDish.cs
+++ b/Customs/Dishes/MysteryMeatHotdogDish.cs
@@ -1,18 +1,18 @@
-﻿using KitchenData;
+using System.Collections.Generic;
+using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Customs.Items;
 using KitchenMysteryMeat.Customs.Processes;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Dishes
 {
+    /// <summary>
+    /// Unlocks the hotdog follow-up dish that expands the menu with casings and minced meat workflows.
+    /// </summary>
     public class MysteryMeatHotdogDish : CustomDish
     {
         public override string UniqueNameID => "MysteryMeatHotdogDish";
@@ -32,41 +32,56 @@ namespace KitchenMysteryMeat.Customs.Dishes
             (Dish)GDOUtils.GetCustomGameDataObject<MysteryMeatBurgerDish>().GameDataObject
         };
 
-        public override List<Dish.MenuItem> ResultingMenuItems => new List<Dish.MenuItem>
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
         {
             new Dish.MenuItem
             {
                 Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.HotdogPlated),
                 Phase = MenuPhase.Main,
-                Weight = 1,
-
+                Weight = 1
             }
         };
 
-        public override HashSet<Item> MinimumIngredients => new HashSet<Item>
+        public override HashSet<Item> MinimumIngredients => new()
         {
             (Item)GDOUtils.GetCustomGameDataObject<MeatCleaver>().GameDataObject,
             (Item)GDOUtils.GetCustomGameDataObject<Casing>().GameDataObject,
-            (Item)GDOUtils.GetExistingGDO(ItemReferences.HotdogBun),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.HotdogBun)
         };
-        public override HashSet<Process> RequiredProcesses => new HashSet<Process>
+
+        public override HashSet<Process> RequiredProcesses => new()
         {
             (Process)GDOUtils.GetExistingGDO(ProcessReferences.Cook),
             GDOUtils.GetCastedGDO<Process, GrindMeat>()
         };
 
-        public override Dictionary<Locale, string> Recipe => new Dictionary<Locale, string>
+        public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English, "Put 'fresh meat' in meat grinder to get minced meat. Combine with a hot dog casing, cook hot dog, and place in bun." }
         };
+
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo
             {
                 Name = "Mystery Meat Hot Dogs",
                 Description = "Adds \"fresh meat\" hot dogs as a main",
-                FlavourText = ""
+                FlavourText = string.Empty
             })
         };
+
+        /// <summary>
+        /// Emits verbose diagnostics listing the new ingredient unlock requirements when registered.
+        /// </summary>
+        /// <param name="gameDataObject">The dish definition being registered.</param>
+        public override void OnRegister(Dish gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int casingId = GDOUtils.GetCustomGameDataObject<Casing>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"MysteryMeatHotdogDish registered with casing dependency {casingId} and burger prerequisite unlock.");
+        }
     }
 }

--- a/Customs/Dishes/MysteryMeatPieDish.cs
+++ b/Customs/Dishes/MysteryMeatPieDish.cs
@@ -1,17 +1,17 @@
-﻿using KitchenData;
+using System.Collections.Generic;
+using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Customs.Items;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Dishes
 {
+    /// <summary>
+    /// Unlocks the pie variant that extends mystery meat into oven-baked dishes with pastry preparation.
+    /// </summary>
     public class MysteryMeatPieDish : CustomDish
     {
         public override string UniqueNameID => "MysteryMeatPieDish";
@@ -31,18 +31,17 @@ namespace KitchenMysteryMeat.Customs.Dishes
             (Dish)GDOUtils.GetCustomGameDataObject<MysteryMeatBurgerDish>().GameDataObject
         };
 
-        public override List<Dish.MenuItem> ResultingMenuItems => new List<Dish.MenuItem>
+        public override List<Dish.MenuItem> ResultingMenuItems => new()
         {
             new Dish.MenuItem
             {
                 Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.PiePlated),
                 Phase = MenuPhase.Main,
-                Weight = 1,
+                Weight = 1
             }
         };
 
-
-        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new HashSet<Dish.IngredientUnlock>
+        public override HashSet<Dish.IngredientUnlock> IngredientsUnlocks => new()
         {
             new Dish.IngredientUnlock
             {
@@ -51,31 +50,47 @@ namespace KitchenMysteryMeat.Customs.Dishes
             }
         };
 
-        public override HashSet<Item> MinimumIngredients => new HashSet<Item>
+        public override HashSet<Item> MinimumIngredients => new()
         {
             (Item)GDOUtils.GetCustomGameDataObject<MeatCleaver>().GameDataObject,
             (Item)GDOUtils.GetExistingGDO(ItemReferences.Water),
             (Item)GDOUtils.GetExistingGDO(ItemReferences.Flour),
-            (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate),
-        };
-        public override HashSet<Process> RequiredProcesses => new HashSet<Process>
-        {
-            (Process)GDOUtils.GetExistingGDO(ProcessReferences.RequireOven),
-            (Process)GDOUtils.GetExistingGDO(ProcessReferences.Knead),
+            (Item)GDOUtils.GetExistingGDO(ItemReferences.Plate)
         };
 
-        public override Dictionary<Locale, string> Recipe => new Dictionary<Locale, string>
+        public override HashSet<Process> RequiredProcesses => new()
+        {
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.RequireOven),
+            (Process)GDOUtils.GetExistingGDO(ProcessReferences.Knead)
+        };
+
+        public override Dictionary<Locale, string> Recipe => new()
         {
             { Locale.English, "Knead flour (or add water) to create dough, then knead into pie crust. Add 'fresh meat' and cook." }
         };
+
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
             (Locale.English, new UnlockInfo
             {
                 Name = "Mystery Meat Pies",
                 Description = "Adds \"fresh meat\" pies as a main",
-                FlavourText = ""
+                FlavourText = string.Empty
             })
         };
+
+        /// <summary>
+        /// Logs the special oven requirement that differentiates the pie unlock.
+        /// </summary>
+        /// <param name="gameDataObject">The dish definition being registered.</param>
+        public override void OnRegister(Dish gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int ovenRequirementId = GDOUtils.GetExistingGDO(ProcessReferences.RequireOven).ID;
+
+            DebugLogSystem.LogVerbose(
+                $"MysteryMeatPieDish registered with oven requirement {ovenRequirementId} and pastry ingredient unlock.");
+        }
     }
 }

--- a/Customs/Dishes/SpecialSauceDish.cs
+++ b/Customs/Dishes/SpecialSauceDish.cs
@@ -1,16 +1,16 @@
-﻿using KitchenData;
+using System.Collections.Generic;
+using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Customs.Items;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 
 namespace KitchenMysteryMeat.Customs.Dishes
 {
+    /// <summary>
+    /// Unlocks the special sauce request system that layers blood refills onto plated meals.
+    /// </summary>
     public class SpecialSauceDish : CustomDish
     {
         public override string UniqueNameID => "SpecialSauceDish";
@@ -29,7 +29,7 @@ namespace KitchenMysteryMeat.Customs.Dishes
             (Dish)GDOUtils.GetCustomGameDataObject<MysteryMeatBurgerDish>().GameDataObject
         };
 
-        public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new HashSet<Dish.IngredientUnlock>
+        public override HashSet<Dish.IngredientUnlock> ExtraOrderUnlocks => new()
         {
             new Dish.IngredientUnlock
             {
@@ -45,27 +45,40 @@ namespace KitchenMysteryMeat.Customs.Dishes
             {
                 Ingredient = GDOUtils.GetCastedGDO<Item, SpecialSauceBottle>(),
                 MenuItem = (ItemGroup)GDOUtils.GetExistingGDO(ItemReferences.PiePlated)
-            },
+            }
         };
 
-        public override HashSet<Item> MinimumIngredients => new HashSet<Item>
+        public override HashSet<Item> MinimumIngredients => new()
         {
-            GDOUtils.GetCastedGDO<Item, EmptySpecialSauceBottle>(),
-        };
-        public override HashSet<Process> RequiredProcesses => new HashSet<Process>
-        {
+            GDOUtils.GetCastedGDO<Item, EmptySpecialSauceBottle>()
         };
 
-        public override Dictionary<Locale, string> Recipe => new Dictionary<Locale, string>
-        {
-            //{ Locale.English, "Use with plated breakfast to add syrup, then serve." }
+        public override HashSet<Process> RequiredProcesses => new();
 
+        public override Dictionary<Locale, string> Recipe => new()
+        {
             { Locale.English, "Fill bottle with blood and serve when requested. Has 6 uses until a refill is needed" }
         };
+
         public override List<(Locale, UnlockInfo)> InfoList => new()
         {
-            //( Locale.English, LocalisationUtils.CreateUnlockInfo("Maple Syrup", "Adds maple syrup as an American Breakfast topping", "Simple yet delicious") )
-            ( Locale.English, LocalisationUtils.CreateUnlockInfo("Special Sauce", "Customers can request the 'special sauce' while eating", null) )
+            (Locale.English, LocalisationUtils.CreateUnlockInfo("Special Sauce", "Customers can request the 'special sauce' while eating", null))
         };
+
+        /// <summary>
+        /// Emits verbose diagnostics listing every plated item that now allows special sauce orders.
+        /// </summary>
+        /// <param name="gameDataObject">The dish definition being registered.</param>
+        public override void OnRegister(Dish gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int burgerId = GDOUtils.GetExistingGDO(ItemReferences.BurgerPlated).ID;
+            int hotdogId = GDOUtils.GetExistingGDO(ItemReferences.HotdogPlated).ID;
+            int pieId = GDOUtils.GetExistingGDO(ItemReferences.PiePlated).ID;
+
+            DebugLogSystem.LogVerbose(
+                $"SpecialSauceDish registered enabling sauce orders for burgers ({burgerId}), hotdogs ({hotdogId}), and pies ({pieId}).");
+        }
     }
 }

--- a/Customs/ItemGroups/BaggedCorpse.cs
+++ b/Customs/ItemGroups/BaggedCorpse.cs
@@ -1,18 +1,19 @@
-﻿/*using Kitchen;
+// This placeholder remains disabled until the bagged corpse workflow returns; summary comments remain for future reactivation.
+#if false
+using Kitchen;
 using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Customs.Items;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.ItemGroups
 {
+    /// <summary>
+    /// Represents a corpse packaged inside a trash bag that splits back into its components when processed.
+    /// </summary>
     internal class BaggedCorpse : CustomItemGroup<ItemGroupView>
     {
         public override string UniqueNameID => "BaggedCorpse";
@@ -24,13 +25,13 @@ namespace KitchenMysteryMeat.Customs.ItemGroups
         public override List<Item> SplitDepletedItems => new() { (Item)GDOUtils.GetCustomGameDataObject<CustomerCorpse>().GameDataObject };
         public override int SplitCount => 1;
         public override float SplitSpeed => 3.0f;
-        public override List<ItemGroup.ItemSet> Sets => new List<ItemGroup.ItemSet>()
+        public override List<ItemGroup.ItemSet> Sets => new List<ItemGroup.ItemSet>
         {
-            new ItemGroup.ItemSet()
+            new ItemGroup.ItemSet
             {
                 Max = 2,
                 Min = 2,
-                Items = new List<Item>()
+                Items = new List<Item>
                 {
                     (Item)GDOUtils.GetCustomGameDataObject<CustomerCorpse>().GameDataObject,
                     (Item)GDOUtils.GetCustomGameDataObject<TrashBag>().GameDataObject,
@@ -39,4 +40,4 @@ namespace KitchenMysteryMeat.Customs.ItemGroups
         };
     }
 }
-*/
+#endif

--- a/Customs/ItemGroups/RawHotdog.cs
+++ b/Customs/ItemGroups/RawHotdog.cs
@@ -1,54 +1,69 @@
-﻿using KitchenData;
+using System.Collections.Generic;
+using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Items;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.ItemGroups
 {
+    /// <summary>
+    /// Represents the raw hotdog assembly composed of minced meat and casings before cooking.
+    /// </summary>
     public class RawHotdog : CustomItemGroup
     {
         public override string UniqueNameID => "RawHotdogItemGroup";
         public override GameObject Prefab => ((Item)GDOUtils.GetExistingGDO(ItemReferences.HotdogRaw)).Prefab;
         public override bool AutoCollapsing => true;
 
-        public override List<ItemGroup.ItemSet> Sets => new List<ItemGroup.ItemSet>()
+        public override List<ItemGroup.ItemSet> Sets => new List<ItemGroup.ItemSet>
         {
-            new ItemGroup.ItemSet()
+            new ItemGroup.ItemSet
             {
                 Max = 1,
                 Min = 1,
                 IsMandatory = true,
-                Items = new List<Item>()
+                Items = new List<Item>
                 {
                     (Item)GDOUtils.GetExistingGDO(ItemReferences.Mince)
                 }
             },
-            new ItemGroup.ItemSet()
+            new ItemGroup.ItemSet
             {
                 Max = 1,
                 Min = 1,
                 IsMandatory = true,
-                Items = new List<Item>()
+                Items = new List<Item>
                 {
                     GDOUtils.GetCastedGDO<Item, Casing>()
                 }
             }
         };
 
-        public override List<IItemProperty> Properties => new List<IItemProperty>()
+        public override List<IItemProperty> Properties => new List<IItemProperty>
         {
-            new CTurnIntoItem()
+            new CTurnIntoItem
             {
                 NewID = ItemReferences.HotdogRaw
             }
         };
+
+        /// <summary>
+        /// Emits verbose diagnostics showing the ingredient IDs that build the raw hotdog assembly.
+        /// </summary>
+        /// <param name="gameDataObject">The item group definition being registered.</param>
+        public override void OnRegister(ItemGroup gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int minceId = GDOUtils.GetExistingGDO(ItemReferences.Mince).ID;
+            int casingId = GDOUtils.GetCustomGameDataObject<Casing>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"RawHotdog registered with mince item {minceId} and casing item {casingId} as mandatory sets.");
+        }
     }
 }

--- a/Customs/ItemGroups/RawPottedLobster.cs
+++ b/Customs/ItemGroups/RawPottedLobster.cs
@@ -1,4 +1,6 @@
-/*using System.Collections.Generic;
+// Legacy lobster support remains disabled but documented for future restoration.
+#if false
+using System.Collections.Generic;
 using Kitchen;
 using KitchenData;
 using KitchenLib.Customs;
@@ -9,42 +11,31 @@ using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.ItemGroups
 {
+    /// <summary>
+    /// Represents the raw lobster pot assembly that cooks into the plated lobster dish.
+    /// </summary>
     public class RawPottedLobster : CustomItemGroup<ItemGroupView>
     {
-        // UniqueNameID - This is used internally to generate the ID of this GDO. Once you've set it, don't change it.
         public override string UniqueNameID => "RawPottedLobster";
-        
-        // Prefab - This is the GameObject used for this Item's visual. AssignMaterialsByNames() is a helper method that assigns materials to the GameObject based on the names of the materials.
         public override GameObject Prefab => Mod.Bundle.LoadAsset<GameObject>("Raw Potted Lobster").AssignMaterialsByNames();
-        
-        // DisposesTo - What this Item turns into when interacted with a bin.
         public override Item DisposesTo => (Item)GDOUtils.GetExistingGDO(ItemReferences.Pot);
-        
-        // Sets - Sets are the Items which make up an ItemGroup.
+
         public override List<ItemGroup.ItemSet> Sets => new List<ItemGroup.ItemSet>
         {
-            // An ItemSets are collections of Items which are required to make this ItemGroup.
             new ItemGroup.ItemSet
             {
-                // Items - The Items required to make complete this ItemSet.
                 Items = new List<Item>
                 {
-                    // GDOUtils.GetExistingGDO(ItemReferences.Plate) - This is a helper method that gets a reference to a vanilla Item.
                     (Item)GDOUtils.GetExistingGDO(ItemReferences.Pot)
                 },
-                // Min - The minimum number of Items required to complete this ItemSet.
-                // Max - The maximum number of Items required to complete this ItemSet.
                 Min = 1,
                 Max = 1,
-                
-                // IsMandatory - When TRUE this ItemSet is required to complete the ItemGroup.
                 IsMandatory = true
             },
             new ItemGroup.ItemSet
             {
                 Items = new List<Item>
                 {
-                    // GDOUtils.GetExistingGDO(ItemReferences.Lobster) - This is a helper method that gets a reference to a modded Item.
                     (Item)GDOUtils.GetCustomGameDataObject<RawLobster>().GameDataObject,
                     (Item)GDOUtils.GetExistingGDO(ItemReferences.Water)
                 },
@@ -52,8 +43,7 @@ namespace KitchenMysteryMeat.Customs.ItemGroups
                 Max = 2
             }
         };
-        
-        // Processes - These are the Processes which can be applied to this Item.
+
         public override List<Item.ItemProcess> Processes => new List<Item.ItemProcess>
         {
             new Item.ItemProcess
@@ -63,22 +53,20 @@ namespace KitchenMysteryMeat.Customs.ItemGroups
                 Result = (Item)GDOUtils.GetCustomGameDataObject<CookedPottedLobster>().GameDataObject
             }
         };
-        
-        // OnRegister - This is called when a GameDataObject is registered.
+
+        /// <summary>
+        /// Configures the item group view so each component renders correctly when crafting the lobster pot.
+        /// </summary>
         public override void OnRegister(ItemGroup gameDataObject)
         {
             base.OnRegister(gameDataObject);
-            
-            // This gets the ItemGroupView component from the Prefab. Unless modified otherwise, this component is automatically added to all ItemGroup Prefabs.
-            ItemGroupView view = gameDataObject.Prefab.GetComponent<ItemGroupView>();
 
-            // This is used to render the correct GameObjects based on the Items in the ItemSets.
+            ItemGroupView view = gameDataObject.Prefab.GetComponent<ItemGroupView>();
             view.ComponentGroups = new List<ItemGroupView.ComponentGroup>
             {
                 new ItemGroupView.ComponentGroup
                 {
                     Item = (Item)GDOUtils.GetExistingGDO(ItemReferences.Pot),
-                    // GameObjectUtils.GetChildObject() is a helper method that gets a child GameObject from the Prefab. The first argument is the parent GameObject, the second is the path to the child GameObject.
                     GameObject = GameObjectUtils.GetChildObject(gameDataObject.Prefab, "Pot/Pot_1"),
                     DrawAll = true
                 },
@@ -97,4 +85,5 @@ namespace KitchenMysteryMeat.Customs.ItemGroups
             };
         }
     }
-}*/
+}
+#endif

--- a/Customs/Items/Casing.cs
+++ b/Customs/Items/Casing.cs
@@ -1,21 +1,34 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Customs.Appliances;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Items
 {
+    /// <summary>
+    /// Represents the casing used when assembling mystery meat hotdogs.
+    /// </summary>
     public class Casing : CustomItem
     {
         public override string UniqueNameID => "Casing";
         public override GameObject Prefab => Mod.Bundle.LoadAsset<GameObject>("Casing").AssignMaterialsByNames();
         public override Appliance DedicatedProvider => (Appliance)GDOUtils.GetCustomGameDataObject<CasingsProvider>().GameDataObject;
         public override ItemStorage ItemStorageFlags => ItemStorage.StackableFood;
+
+        /// <summary>
+        /// Logs the provider relationship for hotdog casings upon registration.
+        /// </summary>
+        /// <param name="gameDataObject">The item definition being registered.</param>
+        public override void OnRegister(Item gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int providerId = GDOUtils.GetCustomGameDataObject<CasingsProvider>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"Casing item registered with dedicated provider {providerId} and stackable storage flag.");
+        }
     }
 }

--- a/Customs/Items/EmptySpecialSauceBottle.cs
+++ b/Customs/Items/EmptySpecialSauceBottle.cs
@@ -1,18 +1,18 @@
-﻿using KitchenData;
+using System.Collections.Generic;
+using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Appliances;
+using KitchenMysteryMeat.Systems.Logging;
 using KitchenMysteryMeat.Views;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Items
 {
+    /// <summary>
+    /// Represents the emptied special sauce bottle that can be refilled at blood spills.
+    /// </summary>
     public class EmptySpecialSauceBottle : CustomItem
     {
         public override string UniqueNameID => "EmptySpecialSauceBottle";
@@ -23,10 +23,24 @@ namespace KitchenMysteryMeat.Customs.Items
 
         public override List<IItemProperty> Properties => new()
         {
-            new CEmptyBottle()
+            new CEmptyBottle
             {
                 FullBottleID = GDOUtils.GetCustomGameDataObject<SpecialSauceBottle>().GameDataObject.ID
             }
         };
+
+        /// <summary>
+        /// Logs the refill target configured for empty special sauce bottles.
+        /// </summary>
+        /// <param name="gameDataObject">The item definition being registered.</param>
+        public override void OnRegister(Item gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int fullBottleId = GDOUtils.GetCustomGameDataObject<SpecialSauceBottle>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"EmptySpecialSauceBottle registered with refill output item {fullBottleId} and dedicated provider enforcement.");
+        }
     }
 }

--- a/Customs/Items/MeatCleaver.cs
+++ b/Customs/Items/MeatCleaver.cs
@@ -1,20 +1,20 @@
-﻿using Kitchen;
+using System.Collections.Generic;
+using Kitchen;
 using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Appliances;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Items
 {
-    class MeatCleaver : CustomItem
+    /// <summary>
+    /// Provides the meat cleaver tool used for chopping processes and lethal interactions.
+    /// </summary>
+    public class MeatCleaver : CustomItem
     {
         public override string UniqueNameID => "MeatCleaver";
         public override GameObject Prefab => Mod.Bundle.LoadAsset<GameObject>("Meat Cleaver").AssignMaterialsByNames().AssignVFXByNames();
@@ -24,18 +24,30 @@ namespace KitchenMysteryMeat.Customs.Items
         public override ItemValue ItemValue => ItemValue.Small;
         public override ToolAttachPoint HoldPose => ToolAttachPoint.Hand;
         public override bool IsIndisposable => true;
+
         public override List<IItemProperty> Properties => new()
         {
-            new CProcessTool()
+            new CProcessTool
             {
                 Process = ProcessReferences.Chop,
                 Factor = 2
             },
-            new CEquippableTool()
+            new CEquippableTool
             {
                 CanHoldItems = true
             },
             new CKillsCustomer()
         };
+
+        /// <summary>
+        /// Emits verbose diagnostics about the cleaver's kill flag and process speed multiplier.
+        /// </summary>
+        /// <param name="gameDataObject">The item definition being registered.</param>
+        public override void OnRegister(Item gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            DebugLogSystem.LogVerbose("MeatCleaver registered with lethal interactions and double-speed chopping capability.");
+        }
     }
 }

--- a/Customs/Items/MysteryMeat.cs
+++ b/Customs/Items/MysteryMeat.cs
@@ -6,10 +6,14 @@ using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Appliances;
 using KitchenMysteryMeat.Customs.Processes;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Items
 {
+    /// <summary>
+    /// Defines the core mystery meat ingredient that can be chopped or ground into other recipes.
+    /// </summary>
     public class MysteryMeat : CustomItem
     {
         public override string UniqueNameID => "MysteryMeat";
@@ -17,14 +21,13 @@ namespace KitchenMysteryMeat.Customs.Items
         public override Appliance DedicatedProvider => (Appliance)GDOUtils.GetCustomGameDataObject<MeatCleaverProvider>().GameDataObject;
         public override ItemStorage ItemStorageFlags => ItemStorage.StackableFood;
 
-
-        public override List<Item.ItemProcess> Processes => new List<Item.ItemProcess>()
+        public override List<Item.ItemProcess> Processes => new List<Item.ItemProcess>
         {
-            new Item.ItemProcess()
+            new Item.ItemProcess
             {
                 Process = (Process)GDOUtils.GetExistingGDO(ProcessReferences.Chop),
                 Duration = 1.0f,
-                Result = (Item)GDOUtils.GetExistingGDO(ItemReferences.MeatChopped),
+                Result = (Item)GDOUtils.GetExistingGDO(ItemReferences.MeatChopped)
             },
             new Item.ItemProcess
             {
@@ -34,9 +37,23 @@ namespace KitchenMysteryMeat.Customs.Items
             }
         };
 
-        public override List<IItemProperty> Properties => new List<IItemProperty>()
+        public override List<IItemProperty> Properties => new List<IItemProperty>
         {
             new CGrindable()
         };
+
+        /// <summary>
+        /// Emits verbose diagnostics about the chopping and grinding routes for mystery meat.
+        /// </summary>
+        /// <param name="gameDataObject">The item definition being registered.</param>
+        public override void OnRegister(Item gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int grindProcessId = GDOUtils.GetCustomGameDataObject<GrindMeat>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"MysteryMeat registered with chop and grind outputs, including grind process {grindProcessId} targeting minced meat.");
+        }
     }
 }

--- a/Customs/Items/PoisonBottle.cs
+++ b/Customs/Items/PoisonBottle.cs
@@ -1,25 +1,24 @@
-﻿using Kitchen;
+using System.Collections.Generic;
+using Kitchen;
 using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Components;
 using KitchenMysteryMeat.Customs.Appliances;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Items
 {
+    /// <summary>
+    /// Defines the poison bottle used to deliver lethal doses to customers.
+    /// </summary>
     public class PoisonBottle : CustomItem
     {
         public override string UniqueNameID => "PoisonBottle";
         public override GameObject Prefab => Mod.Bundle.LoadAsset<GameObject>("Poison Bottle").AssignMaterialsByNames();
         public override Appliance DedicatedProvider => (Appliance)GDOUtils.GetCustomGameDataObject<PoisonProvider>().GameDataObject;
-
         public override bool IsIndisposable => true;
         public override ItemStorage ItemStorageFlags => ItemStorage.None;
 
@@ -27,5 +26,19 @@ namespace KitchenMysteryMeat.Customs.Items
         {
             new CPoisonBottle()
         };
+
+        /// <summary>
+        /// Emits verbose diagnostics confirming poison bottle registration and provider linkage.
+        /// </summary>
+        /// <param name="gameDataObject">The item definition being registered.</param>
+        public override void OnRegister(Item gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int poisonProviderId = GDOUtils.GetCustomGameDataObject<PoisonProvider>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"PoisonBottle registered with dedicated provider {poisonProviderId} and indisposable flag.");
+        }
     }
 }

--- a/Customs/Items/RottenMysteryMeat.cs
+++ b/Customs/Items/RottenMysteryMeat.cs
@@ -1,45 +1,30 @@
-﻿using KitchenData;
+using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.References;
 using KitchenLib.Utils;
-using KitchenMysteryMeat.Components;
-using KitchenMysteryMeat.Customs.Appliances;
-using KitchenMysteryMeat.Customs.Processes;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using KitchenMysteryMeat.Systems.Logging;
 using UnityEngine;
 
 namespace KitchenMysteryMeat.Customs.Items
 {
+    /// <summary>
+    /// Defines the rotten meat variant used for visual storytelling when corpses decay.
+    /// </summary>
     public class RottenMysteryMeat : CustomItem
     {
         public override string UniqueNameID => "RottenMysteryMeat";
         public override GameObject Prefab => Mod.Bundle.LoadAsset<GameObject>("Rotten Mystery Meat").AssignMaterialsByNames().AssignVFXByNames();
         public override ItemStorage ItemStorageFlags => ItemStorage.StackableFood;
 
-
-        /*public override List<Item.ItemProcess> Processes => new List<Item.ItemProcess>()
+        /// <summary>
+        /// Emits diagnostics indicating that rotten meat currently only serves as a cosmetic or narrative prop.
+        /// </summary>
+        /// <param name="gameDataObject">The item definition being registered.</param>
+        public override void OnRegister(Item gameDataObject)
         {
-            new Item.ItemProcess()
-            {
-                Process = (Process)GDOUtils.GetExistingGDO(ProcessReferences.Chop),
-                Duration = 1.0f,
-                Result = (Item)GDOUtils.GetExistingGDO(ItemReferences.MeatChopped),
-            },
-            new Item.ItemProcess
-            {
-                Duration = 2.0f,
-                Process = GDOUtils.GetCastedGDO<Process, GrindMeat>(),
-                Result = (Item)GDOUtils.GetExistingGDO(ItemReferences.Mince)
-            }
-        };
+            base.OnRegister(gameDataObject);
 
-        public override List<IItemProperty> Properties => new List<IItemProperty>()
-        {
-            new CGrindable()
-        };*/
+            DebugLogSystem.LogVerbose("RottenMysteryMeat registered without active processes; serves as decay flavor content.");
+        }
     }
 }

--- a/Customs/Processes/GrindMeat.cs
+++ b/Customs/Processes/GrindMeat.cs
@@ -1,27 +1,38 @@
-﻿using KitchenData;
+using System.Collections.Generic;
+using KitchenData;
 using KitchenLib.Customs;
 using KitchenLib.Utils;
 using KitchenMysteryMeat.Customs.Appliances;
-using System.Collections.Generic;
+using KitchenMysteryMeat.Systems.Logging;
 
 namespace KitchenMysteryMeat.Customs.Processes
 {
+    /// <summary>
+    /// Registers the bespoke grind process so grinders convert corpses into minced meat with dedicated localisation.
+    /// </summary>
     public class GrindMeat : CustomProcess
     {
-        // The unique internal name of this process
         public override string UniqueNameID => "GrindMeat";
-
-        // The "default" appliance of this process (e.g., counter for "chop", hob for "cook")
-        // When a dish requires this process, this is the appliance that will spawn at the beginning of a run
         public override GameDataObject BasicEnablingAppliance => (Appliance)GDOUtils.GetCustomGameDataObject<ManualMeatGrinder>().GameDataObject;
-
-        // Whether or not the process can be obfuscated, such as through the "Blindfolded Chefs" card. This is normally set to `true`
         public override bool CanObfuscateProgress => true;
 
-        // The localization information for this process. This must be set for at least one language.
         public override List<(Locale, ProcessInfo)> InfoList => new()
         {
-            (Locale.English, LocalisationUtils.CreateProcessInfo("Grind", "<sprite name=\"grindmeat\">"))
+            (Locale.English, LocalisationUtils.CreateProcessInfo("Grind", "<sprite name=\"grindmeat\">") )
         };
+
+        /// <summary>
+        /// Emits verbose diagnostics highlighting the default enabling appliance for the grind process.
+        /// </summary>
+        /// <param name="gameDataObject">The process definition being registered.</param>
+        public override void OnRegister(Process gameDataObject)
+        {
+            base.OnRegister(gameDataObject);
+
+            int manualGrinderId = GDOUtils.GetCustomGameDataObject<ManualMeatGrinder>().ID;
+
+            DebugLogSystem.LogVerbose(
+                $"GrindMeat process registered with manual grinder enabling appliance {manualGrinderId}.");
+        }
     }
 }

--- a/UnityProject - MysteryMeat/Assets/Template/Editor/AssetBundler.cs
+++ b/UnityProject - MysteryMeat/Assets/Template/Editor/AssetBundler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
@@ -42,54 +43,153 @@ public class AssetBundler
     private int NumWarnings;
 
     /// <summary>
-    /// Number of warnings encountered.
+    /// Tracks the temporary asset bundle tag generated during build.
     /// </summary>
     private string GeneratedAssetBundleTag;
 
+    /// <summary>
+    /// Provides reflection based access to the runtime debug log system while working inside the Unity editor.
+    /// </summary>
+    private static class EditorDebugLogBridge
+    {
+        private static Type _debugType;
+        private static MethodInfo _infoMethod;
+        private static MethodInfo _warningMethod;
+        private static MethodInfo _errorMethod;
+        private static MethodInfo _verboseMethod;
+
+        private static Type ResolveDebugType()
+        {
+            if (_debugType != null)
+            {
+                return _debugType;
+            }
+
+            // Attempt to locate the runtime logging helper so editor tooling can reuse its configuration.
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                Type candidate = assembly.GetType("KitchenMysteryMeat.Systems.Logging.DebugLogSystem");
+                if (candidate != null)
+                {
+                    _debugType = candidate;
+                    break;
+                }
+            }
+
+            return _debugType;
+        }
+
+        private static MethodInfo ResolveMethod(ref MethodInfo cache, string methodName)
+        {
+            if (cache != null)
+            {
+                return cache;
+            }
+
+            Type debugType = ResolveDebugType();
+            if (debugType != null)
+            {
+                cache = debugType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
+            }
+
+            return cache;
+        }
+
+        private static void Invoke(MethodInfo method, object[] parameters, Action<string> fallback, string message)
+        {
+            if (method != null)
+            {
+                try
+                {
+                    method.Invoke(null, parameters);
+                    return;
+                }
+                catch (Exception)
+                {
+                    // Reflection may fail when the runtime assembly is not loaded; fall back to Unity logging.
+                }
+            }
+
+            fallback?.Invoke(message);
+        }
+
+        public static void LogInfo(string message)
+        {
+            MethodInfo method = ResolveMethod(ref _infoMethod, "LogInfo");
+            Invoke(method, new object[] { message }, m => Debug.Log(m), message);
+        }
+
+        public static void LogWarning(string message)
+        {
+            MethodInfo method = ResolveMethod(ref _warningMethod, "LogWarning");
+            Invoke(method, new object[] { message }, m => Debug.LogWarning(m), message);
+        }
+
+        public static void LogError(string message)
+        {
+            MethodInfo method = ResolveMethod(ref _errorMethod, "LogError");
+            Invoke(method, new object[] { message }, m => Debug.LogError(m), message);
+        }
+
+        public static void LogVerbose(string message)
+        {
+            MethodInfo method = ResolveMethod(ref _verboseMethod, "LogVerbose");
+            Invoke(method, new object[] { message }, m => Debug.Log(m), message);
+        }
+    }
+
+    /// <summary>
+    /// Builds the mod asset bundle while routing progress through the shared debug logging system.
+    /// </summary>
     [MenuItem("PlateUp!/Build Asset Bundle _F6")]
     public static void BuildAssetBundle()
     {
-        Debug.LogFormat("Creating \"{0}\" AssetBundle...", BUNDLE_FILENAME);
+        EditorDebugLogBridge.LogInfo(string.Format("Creating \"{0}\" AssetBundle...", BUNDLE_FILENAME));
 
-		AssetBundler bundler = new AssetBundler();
+        AssetBundler bundler = new AssetBundler();
 
-        if (Application.platform == RuntimePlatform.OSXEditor) bundler.Target = BuildTarget.StandaloneOSX;
+        // Apply the macOS build target when needed so the generated bundle is compatible with the editor.
+        if (Application.platform == RuntimePlatform.OSXEditor)
+        {
+            bundler.Target = BuildTarget.StandaloneOSX;
+        }
 
-        // Randomly generate the resulting name of the asset bundle
+        // Randomly generate the resulting name of the asset bundle.
         bundler.GenerateRandomAssetBundleTag();
 
         bool success = false;
         try
         {
-            // Check for assets
+            // Check for assets and emit warnings when tagging appears incorrect.
             bundler.WarnIfAssetsAreNotTagged();
             bundler.WarnIfZeroAssetsAreTagged();
             bundler.WarnIfMeshAssetsAreTagged();
             // bundler.WarnIfMaterialsAreTaggedOrIncluded();
 
-            // Delete the contents of OUTPUT_FOLDER
+            // Delete the contents of OUTPUT_FOLDER.
             bundler.CleanBuildFolder();
 
-            // Temporarily move the tagged assets to the temporary tag
+            // Temporarily move the tagged assets to the temporary tag.
             bundler.MoveAssetsToTemporaryAssetBundle();
 
-            // Lastly, create the asset bundle itself and copy it to the output folder
+            // Lastly, create the asset bundle itself and copy it to the output folder.
             bundler.CreateAssetBundle();
 
             success = true;
         }
         catch (Exception e)
         {
-            Debug.LogErrorFormat("Failed to build AssetBundle: {0}\n{1}", e.Message, e.StackTrace);
+            EditorDebugLogBridge.LogError(string.Format("Failed to build AssetBundle: {0}\n{1}", e.Message, e.StackTrace));
         }
 
-        // Return assets to the original asset bundle tag
+        // Return assets to the original asset bundle tag.
         bundler.RestoreAssetBundleTags();
         AssetDatabase.RemoveUnusedAssetBundleNames();
 
         if (success)
         {
-            Debug.LogFormat("[{0}] Build complete with {1} warnings! Output: {2} (temporary ID: {3})", DateTime.Now.ToLocalTime(), bundler.NumWarnings, OUTPUT_FOLDER + "/" + BUNDLE_FILENAME, bundler.GeneratedAssetBundleTag);
+            EditorDebugLogBridge.LogInfo(string.Format("[{0}] Build complete with {1} warnings! Output: {2} (temporary ID: {3})",
+                DateTime.Now.ToLocalTime(), bundler.NumWarnings, OUTPUT_FOLDER + "/" + BUNDLE_FILENAME, bundler.GeneratedAssetBundleTag));
         }
     }
 
@@ -100,10 +200,11 @@ public class AssetBundler
     {
         System.Random rand = new System.Random();
         GeneratedAssetBundleTag = $"mod-{rand.Next(0, int.MaxValue)}.assets";
+        EditorDebugLogBridge.LogVerbose($"Generated temporary asset bundle tag {GeneratedAssetBundleTag}.");
     }
 
     /// <summary>
-    /// Move assets tagged with BUNDLE_FILENAME to the temporary asset bundle
+    /// Move assets tagged with BUNDLE_FILENAME to the temporary asset bundle.
     /// </summary>
     private void MoveAssetsToTemporaryAssetBundle()
     {
@@ -111,7 +212,7 @@ public class AssetBundler
     }
 
     /// <summary>
-    /// Move assets tagged with the temporary asset bundle back to BUNDLE_FILENAME
+    /// Move assets tagged with the temporary asset bundle back to BUNDLE_FILENAME.
     /// </summary>
     private void RestoreAssetBundleTags()
     {
@@ -119,19 +220,21 @@ public class AssetBundler
     }
 
     /// <summary>
-    /// Find all assets tagged with a certain asset bundle tag and replace them with another tag
+    /// Find all assets tagged with a certain asset bundle tag and replace them with another tag.
     /// </summary>
-    /// <param name="from">The asset bundle tag to search for</param>
-    /// <param name="to">The new asset bundle tag</param>
+    /// <param name="from">The asset bundle tag to search for.</param>
+    /// <param name="to">The new asset bundle tag.</param>
     private void SubstituteAssetBundleTags(string from, string to)
     {
         string[] assetGUIDs = AssetDatabase.FindAssets($"b:{from}");
         foreach (var assetGUID in assetGUIDs)
         {
             string path = AssetDatabase.GUIDToAssetPath(assetGUID);
-            var importer = AssetImporter.GetAtPath(path);
+            AssetImporter importer = AssetImporter.GetAtPath(path);
             importer.assetBundleName = to;
         }
+
+        EditorDebugLogBridge.LogVerbose(string.Format("Retagged {0} assets from {1} to {2}.", assetGUIDs.Length, from, to));
     }
 
     /// <summary>
@@ -139,8 +242,9 @@ public class AssetBundler
     /// </summary>
     protected void CleanBuildFolder()
     {
-        Debug.LogFormat("Cleaning {0}...", OUTPUT_FOLDER);
+        EditorDebugLogBridge.LogInfo(string.Format("Cleaning {0}...", OUTPUT_FOLDER));
 
+        // Guard: remove the existing output directory to avoid stale bundles.
         if (Directory.Exists(OUTPUT_FOLDER))
         {
             Directory.Delete(OUTPUT_FOLDER, true);
@@ -154,9 +258,9 @@ public class AssetBundler
     /// </summary>
     protected void CreateAssetBundle()
     {
-        Debug.Log("Building AssetBundle...");
+        EditorDebugLogBridge.LogInfo("Building AssetBundle...");
 
-        // Build all AssetBundles to the TEMP_BUILD_FOLDER
+        // Guard: ensure the temporary folder exists before writing bundles to disk.
         if (!Directory.Exists(TEMP_BUILD_FOLDER))
         {
             Directory.CreateDirectory(TEMP_BUILD_FOLDER);
@@ -173,7 +277,7 @@ public class AssetBundler
 #pragma warning restore 618
 
         // We are only interested in the BUNDLE_FILENAME bundle (and not any extra AssetBundle or the manifest files
-        // that Unity makes), so just copy that to the final output folder
+        // that Unity makes), so just copy that to the final output folder.
         string srcPath = Path.Combine(TEMP_BUILD_FOLDER, GeneratedAssetBundleTag);
         string destPath = Path.Combine(OUTPUT_FOLDER, BUNDLE_FILENAME);
         File.Copy(srcPath, destPath, true);
@@ -211,11 +315,10 @@ public class AssetBundler
                 continue;
             }
 
-            var importer = AssetImporter.GetAtPath(path);
+            AssetImporter importer = AssetImporter.GetAtPath(path);
             if (!importer.assetBundleName.Equals(BUNDLE_FILENAME))
             {
-                // Debug.LogWarningFormat("Asset \"{0}\" is not tagged with \"{1}\" and will not be included in the AssetBundle!", path, BUNDLE_FILENAME);
-                // ++NumWarnings;
+                // Future enhancement: emit warnings when assets are skipped from the bundle build.
             }
         }
     }
@@ -228,7 +331,7 @@ public class AssetBundler
         string[] assetsInBundle = AssetDatabase.FindAssets($"{ASSET_SEARCH_QUERY},b:{BUNDLE_FILENAME}");
         if (assetsInBundle.Length == 0)
         {
-            // throw new Exception(string.Format("No assets have been tagged for inclusion in the {0} AssetBundle.", BUNDLE_FILENAME));
+            // Future enhancement: throw when no assets are tagged to avoid distributing empty bundles.
         }
     }
 
@@ -246,7 +349,7 @@ public class AssetBundler
                 continue;
             }
 
-            Debug.LogWarningFormat("Mesh asset \"{0}\" is tagged for inclusion in the {1} AssetBundle! This is likely a mistake. You should include a prefab instead.", path, BUNDLE_FILENAME);
+            EditorDebugLogBridge.LogWarning(string.Format("Mesh asset \"{0}\" is tagged for inclusion in the {1} AssetBundle! This is likely a mistake. You should include a prefab instead.", path, BUNDLE_FILENAME));
             ++NumWarnings;
         }
     }
@@ -256,7 +359,7 @@ public class AssetBundler
     /// </summary>
     protected void WarnIfMaterialsAreTaggedOrIncluded()
     {
-        // Check for directly tagged materials
+        // Check for directly tagged materials.
         string[] assetGUIDs = AssetDatabase.FindAssets($"t:material,b:{BUNDLE_FILENAME}");
         foreach (var assetGUID in assetGUIDs)
         {
@@ -266,11 +369,11 @@ public class AssetBundler
                 continue;
             }
 
-            Debug.LogWarningFormat("Material asset \"{0}\" is tagged for inclusion in the {1} AssetBundle! This is likely a mistake. You should use generate materials using the vanilla shaders instead.", path, BUNDLE_FILENAME);
+            EditorDebugLogBridge.LogWarning(string.Format("Material asset \"{0}\" is tagged for inclusion in the {1} AssetBundle! This is likely a mistake. You should use generate materials using the vanilla shaders instead.", path, BUNDLE_FILENAME));
             ++NumWarnings;
         }
 
-        // Check for materials assigned to prefabs
+        // Check for materials assigned to prefabs.
         assetGUIDs = AssetDatabase.FindAssets($"t:prefab,b:{BUNDLE_FILENAME}");
         foreach (var assetGUID in assetGUIDs)
         {
@@ -286,20 +389,31 @@ public class AssetBundler
             {
                 if (renderer.sharedMaterials.Any(m => m != null))
                 {
-                    Debug.LogWarningFormat("Material found attached to bundle prefab in \"{0}\" at \"<root>/{1}\"! This is likely a mistake. To avoid log spam and texturing issues, you should remove these materials or set them to \"None\".", path, GetGameObjectPath(renderer.transform).Split(new char[] { '/' }, 3)[2]);
+                    EditorDebugLogBridge.LogWarning(string.Format("Material found attached to bundle prefab in \"{0}\" at \"<root>/{1}\"! This is likely a mistake. To avoid log spam and texturing issues, you should remove these materials or set them to \"None\".", path, GetGameObjectPath(renderer.transform).Split(new char[] { '/' }, 3)[2]));
                     ++NumWarnings;
                 }
             }
         }
     }
 
+    /// <summary>
+    /// Computes the hierarchical path to a Unity transform for diagnostic output.
+    /// </summary>
+    /// <param name="current">The transform to trace.</param>
+    /// <returns>The slash delimited path for the transform.</returns>
     public static string GetGameObjectPath(Transform current)
     {
         if (current.parent == null)
+        {
             return "/" + current.name;
+        }
+
         return GetGameObjectPath(current.parent) + "/" + current.name;
     }
 
+    /// <summary>
+    /// Removes all materials from prefabs tagged for the bundle after explicit user confirmation.
+    /// </summary>
     [MenuItem("PlateUp!/Preparation/[Deprecated] Strip Materials From Prefabs")]
     public static void RemoveAllPrefabMaterials()
     {
@@ -324,16 +438,17 @@ public class AssetBundler
                 if (renderer.sharedMaterials.Length > 0)
                 {
                     renderer.sharedMaterials = new Material[renderer.sharedMaterials.Length];
-                    Debug.LogFormat("Stripped materials from \"{0}\" at \"<root>/{1}\".", path, GetGameObjectPath(renderer.transform).Split(new char[] { '/' }, 3)[2]);
+                    EditorDebugLogBridge.LogInfo(string.Format("Stripped materials from \"{0}\" at \"<root>/{1}\".", path, GetGameObjectPath(renderer.transform).Split(new char[] { '/' }, 3)[2]));
                 }
             }
         }
 
-        Debug.LogFormat("[{0}] Done stripping materials.", DateTime.Now.ToLocalTime());
+        EditorDebugLogBridge.LogInfo(string.Format("[{0}] Done stripping materials.", DateTime.Now.ToLocalTime()));
     }
 
-
-
+    /// <summary>
+    /// Replaces all bundle prefab materials with Unity's default material after explicit user confirmation.
+    /// </summary>
     [MenuItem("PlateUp!/Preparation/[Deprecated] Set Prefab Materials to Default")]
     public static void SetAllPrefabMaterialsToDefault()
     {
@@ -359,7 +474,7 @@ public class AssetBundler
             {
                 if (renderer.sharedMaterials.Length > 0)
                 {
-                    var newMaterials = new Material[renderer.sharedMaterials.Length];
+                    Material[] newMaterials = new Material[renderer.sharedMaterials.Length];
 
                     for (int i = 0; i < newMaterials.Length; i++)
                     {
@@ -368,11 +483,11 @@ public class AssetBundler
 
                     renderer.sharedMaterials = newMaterials;
 
-                    Debug.LogFormat("Set materials from \"{0}\" at \"<root>/{1}\".", path, GetGameObjectPath(renderer.transform).Split(new char[] { '/' }, 3)[2]);
+                    EditorDebugLogBridge.LogInfo(string.Format("Set materials from \"{0}\" at \"<root>/{1}\".", path, GetGameObjectPath(renderer.transform).Split(new char[] { '/' }, 3)[2]));
                 }
             }
         }
 
-        Debug.LogFormat("[{0}] Done setting materials.", DateTime.Now.ToLocalTime());
+        EditorDebugLogBridge.LogInfo(string.Format("[{0}] Done setting materials.", DateTime.Now.ToLocalTime()));
     }
 }

--- a/UnityProject - MysteryMeat/Assets/Template/Editor/EmptyAtZero_Creator.cs
+++ b/UnityProject - MysteryMeat/Assets/Template/Editor/EmptyAtZero_Creator.cs
@@ -1,29 +1,37 @@
 /*Script created by Pierre Stempin*/
 
-using UnityEngine;
 using UnityEditor;
+using UnityEngine;
 
 namespace EmptyAtZeroCreator
 {
-	public class EmptyAtZero_Creator 
-	{
-		const string _Space = EmptyCreator._Space;
+    /// <summary>
+    /// Adds a menu option that spawns an empty GameObject at the world origin.
+    /// </summary>
+    public class EmptyAtZero_Creator
+    {
+        private const string Space = EmptyCreator._Space;
+        private const string FeatureName = EmptyCreator.CreateEmpty_ + EmptyCreator.At + Space + EmptyCreator.Zero;
+        private const string ShortcutName = EmptyCreator.AltSymbol + EmptyCreator.ShortcutLetter;
+        private const string PathName = EmptyCreator._GameObject + EmptyCreator.Slash + FeatureName + Space + ShortcutName;
 
-		const string featureName = EmptyCreator.CreateEmpty_ + EmptyCreator.At + _Space + EmptyCreator.Zero;
-		const string pathName = EmptyCreator._GameObject + EmptyCreator.Slash + featureName + _Space + shortcutName;
-		const string shortcutName = EmptyCreator.AltSymbol + EmptyCreator.ShortcutLetter;
-
-		[MenuItem (pathName, false, -1)]
+        /// <summary>
+        /// Spawns an empty GameObject at the origin, deselecting the current context.
+        /// </summary>
+        /// <param name="menuCommand">The originating Unity menu command context.</param>
+        [MenuItem(PathName, false, -1)]
 #if UNITY_4_6 || UNITY_4_7 || UNITY_5 || UNITY_2017_1_OR_NEWER
-        public static void CreateEmptyAtZero (MenuCommand menuCommand)
-		{
-            EmptyCreator.CreateEmptyGameObject (featureName, true, false, menuCommand);
+        public static void CreateEmptyAtZero(MenuCommand menuCommand)
+        {
+            EmptyCreator.CreateEmptyGameObject(FeatureName, true, false, menuCommand);
+            EmptyCreator.LogVerbose("EmptyAtZero menu action spawned a world-origin GameObject.");
         }
 #else
-        public static void CreateEmptyAtZero ()
-		{
-            EmptyCreator.CreateEmptyGameObject (featureName, true, false);
-		}
+        public static void CreateEmptyAtZero()
+        {
+            EmptyCreator.CreateEmptyGameObject(FeatureName, true, false);
+            EmptyCreator.LogVerbose("EmptyAtZero menu action spawned a world-origin GameObject.");
+        }
 #endif
-	}
+    }
 }

--- a/UnityProject - MysteryMeat/Assets/Template/Editor/EmptyChildAtGlobalZero_Creator.cs
+++ b/UnityProject - MysteryMeat/Assets/Template/Editor/EmptyChildAtGlobalZero_Creator.cs
@@ -1,30 +1,37 @@
 /*Script created by Pierre Stempin*/
 
-using UnityEngine;
 using UnityEditor;
+using UnityEngine;
 
-namespace EmptyAtZeroCreator 
+namespace EmptyAtZeroCreator
 {
-	public class EmptyChildAtGlobalZero_Creator 
-	{
-		const string _Space = EmptyCreator._Space;
-		const string Slash = EmptyCreator.Slash;
+    /// <summary>
+    /// Adds a menu option that spawns an empty child at the global origin beneath the current selection.
+    /// </summary>
+    public class EmptyChildAtGlobalZero_Creator
+    {
+        private const string Space = EmptyCreator._Space;
+        private const string Global = "Global";
+        private const string FeatureName = EmptyCreator.CreateEmptyChildAt_ + Global + Space + EmptyCreator.Zero;
+        private const string ShortcutName = EmptyCreator.ControlSymbol + EmptyCreator.AltSymbol + EmptyCreator.ShortcutLetter;
+        private const string PathName = EmptyCreator._GameObject + EmptyCreator.Slash + FeatureName + Space + ShortcutName;
 
-		const string _global = "Global";
-		const string featureName = EmptyCreator.CreateEmptyChildAt_ + _global + _Space + EmptyCreator.Zero;
-		const string pathName = EmptyCreator._GameObject + EmptyCreator.Slash + featureName + _Space + shortcutName;
-		const string shortcutName = EmptyCreator.ControlSymbol + EmptyCreator.AltSymbol + EmptyCreator.ShortcutLetter;
-
-		[MenuItem (pathName, false)]
+        /// <summary>
+        /// Creates an empty child aligned to global zero beneath the selected GameObject.
+        /// </summary>
+        /// <param name="menuCommand">The originating Unity menu command context.</param>
+        [MenuItem(PathName, false)]
 #if UNITY_4_6 || UNITY_4_7 || UNITY_5 || UNITY_2017_1_OR_NEWER
-        public static void CreateEmptyChildAtGlobalZero (MenuCommand menuCommand)
-		{
-			EmptyCreator.CreateEmptyGameObject (featureName, false, false, menuCommand);
-		}
-#else
-        public static void CreateEmptyChildAtGlobalZero () 
+        public static void CreateEmptyChildAtGlobalZero(MenuCommand menuCommand)
         {
-            EmptyCreator.CreateEmptyGameObject (featureName, false, false);
+            EmptyCreator.CreateEmptyGameObject(FeatureName, false, false, menuCommand);
+            EmptyCreator.LogVerbose("EmptyChildAtGlobalZero menu action spawned a child at global zero.");
+        }
+#else
+        public static void CreateEmptyChildAtGlobalZero()
+        {
+            EmptyCreator.CreateEmptyGameObject(FeatureName, false, false);
+            EmptyCreator.LogVerbose("EmptyChildAtGlobalZero menu action spawned a child at global zero.");
         }
 #endif
     }

--- a/UnityProject - MysteryMeat/Assets/Template/Editor/EmptyChildAtLocalZero_Creator.cs
+++ b/UnityProject - MysteryMeat/Assets/Template/Editor/EmptyChildAtLocalZero_Creator.cs
@@ -1,30 +1,37 @@
 /*Script created by Pierre Stempin*/
 
-using UnityEngine;
 using UnityEditor;
+using UnityEngine;
 
-namespace EmptyAtZeroCreator 
+namespace EmptyAtZeroCreator
 {
-	public class EmptyChildAtLocalZero_Creator 
-	{
-		const string _Space = EmptyCreator._Space;
-		const string Slash = EmptyCreator.Slash;
+    /// <summary>
+    /// Adds a menu option that spawns an empty child aligned to local zero beneath the current selection.
+    /// </summary>
+    public class EmptyChildAtLocalZero_Creator
+    {
+        private const string Space = EmptyCreator._Space;
+        private const string Local = "Local";
+        private const string FeatureName = EmptyCreator.CreateEmptyChildAt_ + Local + Space + EmptyCreator.Zero;
+        private const string ShortcutName = EmptyCreator.ControlSymbol + EmptyCreator.AltSymbol + EmptyCreator.ShiftSymbol + EmptyCreator.ShortcutLetter;
+        private const string PathName = EmptyCreator._GameObject + EmptyCreator.Slash + FeatureName + Space + ShortcutName;
 
-		const string _local = "Local";
-		const string featureName = EmptyCreator.CreateEmptyChildAt_ + _local + _Space + EmptyCreator.Zero;
-		const string pathName = EmptyCreator._GameObject + EmptyCreator.Slash + featureName + _Space + shortcutName;
-		const string shortcutName = EmptyCreator.ControlSymbol + EmptyCreator.AltSymbol + EmptyCreator.ShiftSymbol + EmptyCreator.ShortcutLetter;
-
-        [MenuItem (pathName, false)]
+        /// <summary>
+        /// Creates an empty child reset to local zero beneath the selected GameObject.
+        /// </summary>
+        /// <param name="menuCommand">The originating Unity menu command context.</param>
+        [MenuItem(PathName, false)]
 #if UNITY_4_6 || UNITY_4_7 || UNITY_5 || UNITY_2017_1_OR_NEWER
-        public static void CreateEmptyChildAtLocalZero (MenuCommand menuCommand)
-		{
-			EmptyCreator.CreateEmptyGameObject (featureName, false, true, menuCommand);
-		}
-#else
-        public static void CreateEmptyChildAtLocalZero () 
+        public static void CreateEmptyChildAtLocalZero(MenuCommand menuCommand)
         {
-            EmptyCreator.CreateEmptyGameObject (featureName, false, true);
+            EmptyCreator.CreateEmptyGameObject(FeatureName, false, true, menuCommand);
+            EmptyCreator.LogVerbose("EmptyChildAtLocalZero menu action spawned a child at local zero.");
+        }
+#else
+        public static void CreateEmptyChildAtLocalZero()
+        {
+            EmptyCreator.CreateEmptyGameObject(FeatureName, false, true);
+            EmptyCreator.LogVerbose("EmptyChildAtLocalZero menu action spawned a child at local zero.");
         }
 #endif
     }

--- a/UnityProject - MysteryMeat/Assets/Template/Editor/EmptyCreator.cs
+++ b/UnityProject - MysteryMeat/Assets/Template/Editor/EmptyCreator.cs
@@ -1,97 +1,184 @@
 /*Script created by Pierre Stempin*/
 
-using UnityEngine;
+using System;
+using System.Reflection;
 using UnityEditor;
+using UnityEngine;
 
-namespace EmptyAtZeroCreator 
+namespace EmptyAtZeroCreator
 {
-	public class EmptyCreator 
-	{
-		public const string _GameObject = "GameObject";
-		public const string _Tools = "Tools";
+    /// <summary>
+    /// Provides shared helper methods for creating empty GameObjects at common anchor points via the Unity editor menu.
+    /// </summary>
+    public class EmptyCreator
+    {
+        public const string _GameObject = "GameObject";
+        public const string _Tools = "Tools";
 
-		public const string _Space = " ";
-		public const string Slash = "/";
+        public const string _Space = " ";
+        public const string Slash = "/";
 
-		public const string CreateEmpty_ = create + _Space + empty + _Space;
-		public const string EmptyAtZeroCreator = empty + _Space + At + _Space + Zero + _Space + creator;
-		public const string CreateEmptyChildAt_ = CreateEmpty_ + Child + _Space + At + _Space;
+        public const string CreateEmpty_ = create + _Space + empty + _Space;
+        public const string EmptyAtZeroCreator = empty + _Space + At + _Space + Zero + _Space + creator;
+        public const string CreateEmptyChildAt_ = CreateEmpty_ + Child + _Space + At + _Space;
 
-		const string create = "Create";
-		const string empty = "Empty";
-		const string creator = "Creator";
-		const string Child = "Child";
+        private const string create = "Create";
+        private const string empty = "Empty";
+        private const string creator = "Creator";
+        private const string Child = "Child";
 
-		public const string At = "At";
-		public const string Zero = "Zero";
+        public const string At = "At";
+        public const string Zero = "Zero";
 
-		public const string ShortcutLetter = "N";
-		public const string ControlSymbol = "%";
-		public const string ShiftSymbol = "#";
-		public const string AltSymbol = "&";
+        public const string ShortcutLetter = "N";
+        public const string ControlSymbol = "%";
+        public const string ShiftSymbol = "#";
+        public const string AltSymbol = "&";
+
+        /// <summary>
+        /// Bridges editor logging to the runtime debug log system when available.
+        /// </summary>
+        private static class EditorDebugLogBridge
+        {
+            private static Type _debugType;
+            private static MethodInfo _verboseMethod;
+
+            private static Type ResolveDebugType()
+            {
+                if (_debugType != null)
+                {
+                    return _debugType;
+                }
+
+                foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+                {
+                    Type candidate = assembly.GetType("KitchenMysteryMeat.Systems.Logging.DebugLogSystem");
+                    if (candidate != null)
+                    {
+                        _debugType = candidate;
+                        break;
+                    }
+                }
+
+                return _debugType;
+            }
+
+            private static MethodInfo ResolveVerboseMethod()
+            {
+                if (_verboseMethod != null)
+                {
+                    return _verboseMethod;
+                }
+
+                Type debugType = ResolveDebugType();
+                if (debugType != null)
+                {
+                    _verboseMethod = debugType.GetMethod("LogVerbose", BindingFlags.Public | BindingFlags.Static);
+                }
+
+                return _verboseMethod;
+            }
+
+            public static void LogVerbose(string message)
+            {
+                MethodInfo method = ResolveVerboseMethod();
+                if (method != null)
+                {
+                    try
+                    {
+                        method.Invoke(null, new object[] { message });
+                        return;
+                    }
+                    catch (Exception)
+                    {
+                        // Fall back to Unity logging when the runtime assembly is not available.
+                    }
+                }
+
+                Debug.Log(message);
+            }
+        }
+
+        /// <summary>
+        /// Emits verbose diagnostics through the shared logging bridge so menu actions can be traced.
+        /// </summary>
+        /// <param name="message">The message to record.</param>
+        internal static void LogVerbose(string message)
+        {
+            EditorDebugLogBridge.LogVerbose(message);
+        }
 
 #if UNITY_4_6 || UNITY_4_7 || UNITY_5 || UNITY_2017_1_OR_NEWER
-        public static void CreateEmptyGameObject (string _featureName, bool hasToDeselect, bool hasToResetLocalValues, MenuCommand menuCommand)
+        /// <summary>
+        /// Creates a new empty GameObject and optionally parents or zeroes it based on the caller preferences.
+        /// </summary>
+        /// <param name="featureName">The menu feature name used for undo context.</param>
+        /// <param name="hasToDeselect">Whether to deselect the current object before spawning the new one.</param>
+        /// <param name="hasToResetLocalValues">Whether to zero the spawned object's local transform.</param>
+        /// <param name="menuCommand">The originating menu command so parenting is applied correctly.</param>
+        public static void CreateEmptyGameObject(string featureName, bool hasToDeselect, bool hasToResetLocalValues, MenuCommand menuCommand)
 #else
-        public static void CreateEmptyGameObject (string _featureName, bool hasToDeselect, bool hasToResetLocalValues) 
+        public static void CreateEmptyGameObject(string featureName, bool hasToDeselect, bool hasToResetLocalValues)
 #endif
         {
+            // Guard: reset the selection to avoid inheriting the wrong parent when requested.
             if (hasToDeselect)
-			{
-				//Reset selection
-				Selection.activeGameObject = null;
-			}
+            {
+                Selection.activeGameObject = null;
+            }
 
-			//Create the new empty gameObject
-			string gameObjectName = _GameObject;
-			GameObject spawnedGameObject = new GameObject (gameObjectName);
+            // Create the new empty GameObject so designers can position it immediately.
+            string gameObjectName = _GameObject;
+            GameObject spawnedGameObject = new GameObject(gameObjectName);
 
-
-			if (hasToDeselect)
-			{
+            if (hasToDeselect)
+            {
 #if UNITY_4_6 || UNITY_4_7 || UNITY_5 || UNITY_2017_1_OR_NEWER
-                GameObjectUtility.SetParentAndAlign (spawnedGameObject, menuCommand.context as GameObject);
+                GameObjectUtility.SetParentAndAlign(spawnedGameObject, menuCommand.context as GameObject);
 #endif
             }
 
-            //Undo
-            string undoMethodName = _featureName;
-			Undo.RegisterCreatedObjectUndo (spawnedGameObject, undoMethodName);
+            // Register undo information so the action can be reverted cleanly.
+            Undo.RegisterCreatedObjectUndo(spawnedGameObject, featureName);
 
-			if (Selection.activeGameObject != null)
-			{
-				//Set parent
-				spawnedGameObject.transform.parent = Selection.activeGameObject.transform;
+            if (Selection.activeGameObject != null)
+            {
+                // Parent the spawned object to the current selection when available.
+                spawnedGameObject.transform.parent = Selection.activeGameObject.transform;
 
-				if (hasToResetLocalValues)
-				{
-					//Reset local values
-					spawnedGameObject.transform.localPosition = Vector3.zero;
-					spawnedGameObject.transform.localRotation = Quaternion.identity;
-					spawnedGameObject.transform.localScale = Vector3.one;
-				}
-			}
+                if (hasToResetLocalValues)
+                {
+                    // Reset the local transform so anchors align with the parent.
+                    spawnedGameObject.transform.localPosition = Vector3.zero;
+                    spawnedGameObject.transform.localRotation = Quaternion.identity;
+                    spawnedGameObject.transform.localScale = Vector3.one;
+                }
+            }
 
-			//Select the spawned gameObject
-			Selection.activeGameObject = spawnedGameObject;
+            // Select the spawned GameObject so further edits affect it immediately.
+            Selection.activeGameObject = spawnedGameObject;
 
 #if UNITY_4_6 || UNITY_4_7 || UNITY_5 || UNITY_2017_1_OR_NEWER
-			//Add a RectTransform if needed
-			if (spawnedGameObject.transform.parent != null)
-			{
-				RectTransform parentRectTransform = spawnedGameObject.transform.parent.GetComponent <RectTransform> ();
-				
-				if (parentRectTransform != null)
-				{
-					RectTransform rectTransform = spawnedGameObject.gameObject.AddComponent (typeof (RectTransform)) as RectTransform;
-					rectTransform.anchorMin = Vector2.zero;
-					rectTransform.anchorMax = Vector2.one;
-					rectTransform.offsetMin = Vector2.zero;
-					rectTransform.offsetMax = Vector2.zero;
-				}
-			}
-#endif
-		}
-	}
-}
+            // Add a RectTransform when the parent uses UI layout components.
+            if (spawnedGameObject.transform.parent != null)
+            {
+                RectTransform parentRectTransform = spawnedGameObject.transform.parent.GetComponent<RectTransform>();
 
+                if (parentRectTransform != null)
+                {
+                    RectTransform rectTransform = spawnedGameObject.gameObject.AddComponent(typeof(RectTransform)) as RectTransform;
+                    rectTransform.anchorMin = Vector2.zero;
+                    rectTransform.anchorMax = Vector2.one;
+                    rectTransform.offsetMin = Vector2.zero;
+                    rectTransform.offsetMax = Vector2.zero;
+                }
+            }
+#endif
+
+            EditorDebugLogBridge.LogVerbose(string.Format("Created empty GameObject '{0}' via {1} with parent {2}.",
+                spawnedGameObject.name,
+                featureName,
+                spawnedGameObject.transform.parent != null ? spawnedGameObject.transform.parent.name : "<none>"));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add descriptive summaries to outstanding components and gameplay content to satisfy CommentDebugBacklog requirements
- integrate preference-aware debug logging across blood spill appliances, unlock dishes, and runtime item registrations
- update Unity editor tooling with documentation and reflection-based logging to honour the new debug system

## Testing
- `dotnet build MysteryMeat.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b41717ec832eb7d22fa2bf904987